### PR TITLE
✅ Prevent E2E test on draft pull-request

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_call:
     inputs:
       is_preprod:
@@ -22,6 +23,8 @@ env:
 jobs:
   # Build and setup job - runs on a single machine
   build-and-setup:
+    # Skip entire workflow if PR is a draft (all other jobs depend on this one)
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     environment: 'Test E2E'
     runs-on: ubuntu-latest
     name: Build & Setup Tests
@@ -128,7 +131,7 @@ jobs:
 
   # Merge reports from all shards
   merge-reports:
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.e2e-tests.result != 'skipped' }}
     needs: [e2e-tests]
     runs-on: ubuntu-latest
     name: Merge E2E Reports

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig<FixturesOptions>({
   testDir: './e2e',
   fullyParallel: true,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 6 : undefined,
+  workers: process.env.CI ? 3 : undefined,
   use: {
     baseURL: process.env.NEXT_PUBLIC_SITE_URL,
     trace: process.env.CI ? 'on-first-retry' : 'on',


### PR DESCRIPTION
In order to : 
- save time
- save emails sending