### PR TITLE
Setup devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,42 +1,47 @@
 // Dev Container — Docker Compose setup
 {
-  "name": "nosgestesclimat-server",
+  "name": "nosgestesclimat",
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
-  "workspaceFolder": "/workspaces/nosgestesclimat-server",
+  "workspaceFolder": "/workspaces/nosgestesclimat",
   "remoteUser": "root",
 
   "postCreateCommand": {
-    "pnpm": "corepack enable && corepack install && pnpm install",
+    "pnpm": "corepack enable && corepack install && pnpm install"
   },
 
-  "postStartCommand": {
-    "db": "pnpm build && pnpm db:migrate && pnpm db:post-migrate",
-  },
+  "postStartCommand": ".devcontainer/start.sh",
 
-  "forwardPorts": [3001, 5432, 6379],
+  "forwardPorts": [3000, 3001, 5432, 6379],
   "portsAttributes": {
-    "3001": {
-      "label": "App",
+    "3000": {
+      "label": "Site",
       "onAutoForward": "notify",
       "elevateIfNeeded": false,
       "requireLocalPort": false,
-      "protocol": "http",
+      "protocol": "http"
+    },
+    "3001": {
+      "label": "Server",
+      "onAutoForward": "notify",
+      "elevateIfNeeded": false,
+      "requireLocalPort": false,
+      "protocol": "http"
     },
     "5432": {
       "label": "PostgreSQL",
       "onAutoForward": "silent",
       "elevateIfNeeded": false,
       "requireLocalPort": false,
-      "protocol": "http",
+      "protocol": "http"
     },
     "6379": {
       "label": "Redis",
       "onAutoForward": "silent",
       "elevateIfNeeded": false,
       "requireLocalPort": false,
-      "protocol": "http",
-    },
+      "protocol": "http"
+    }
   },
 
   "customizations": {
@@ -44,8 +49,8 @@
       "extensions": [
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "prisma.prisma",
-      ],
-    },
-  },
+        "prisma.prisma"
+      ]
+    }
+  }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,9 +3,10 @@ services:
     image: node:22-alpine
     command: sleep infinity
     ports:
-      - '3001:3001'
+      - "3000:3000"
+      - "3001:3001"
     volumes:
-      - ../:/workspaces/nosgestesclimat-server:cached,z
+      - ../:/workspaces/nosgestesclimat:cached,z
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/ngc
       REDIS_URL: redis://redis:6379
@@ -18,7 +19,7 @@ services:
     image: postgres:15
     restart: unless-stopped
     ports:
-      - '5432:5432'
+      - "5432:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -30,7 +31,7 @@ services:
     image: redis:7
     restart: unless-stopped
     ports:
-      - '6379:6379'
+      - "6379:6379"
     volumes:
       - redis-data:/data
 

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+[ -f .devcontainer/.env ] && . .devcontainer/.env
+
+MODE=${DEVCONTAINER_START_MODE:-development}
+
+if [ "$MODE" = "production" ]; then
+  echo "📦 Building for production..."
+  NODE_ENV=production pnpm run build
+  pnpm -F server db:migrate
+  pnpm -F server db:post-migrate
+  NODE_ENV=production pnpm run start
+else
+  echo "🔧 Starting in dev mode..."
+  pnpm -F server build
+  pnpm -F server db:migrate
+  pnpm -F server db:post-migrate
+  pnpm run dev
+fi

--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ Pré-requis :
 - [Node.js 22.14.0](https://nodejs.org/fr/download)
 - [pnpm](https://pnpm.io/installation)
 
+### Via devcontainers (recommandé)
+
+Lance les devcontainers via [l'extension VSCode](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) (`Cmd+Shift+P` > `Dev Containers: Reopen in Container`) ou via [la ligne de commande](https://github.com/devcontainers/cli) :
+
+```bash
+devcontainer up
+```
+
+Pour lancer les devcontainers avec un build de production :
+
+```bash
+echo "DEVCONTAINER_START_MODE=production" > .devcontainer/.env
+```
+
+### Manuellement
+
 Installez les dépendances du monorepo :
 
 ```bash
@@ -38,12 +54,6 @@ Installe les dépendances
 
 ```bash
 pnpm install
-```
-
-Lance les services bases de données avec devcontainers via [l'extension VSCode](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) (`Cmd+Shift+P` > `Dev Containers: Reopen in Container`) ou via [la ligne de commande](https://github.com/devcontainers/cli) :
-
-```bash
-devcontainer up
 ```
 
 Migre la base de donnée (requiert les dépendances, les .env et les services)


### PR DESCRIPTION
generate-doc.sh dépend de bash et le devcontainer utilise sh car c'est une Alpine. Il faut trancher :
- Soit on change le script
- Soit on change Alpine
- Soit on change la manière dont la doc est générée