### PR TITLE
🐛 Prevent VerifiedUser to be created without User

### DIFF
--- a/apps/server/scripts/NGC-3379-20260513.ts
+++ b/apps/server/scripts/NGC-3379-20260513.ts
@@ -1,0 +1,39 @@
+import { prisma } from '../src/adapters/prisma/client.ts'
+import logger from '../src/logger.ts'
+
+const main = async () => {
+  try {
+    const result = await prisma.$queryRaw<
+      { count: string }[]
+    >`SELECT COUNT(*)::text FROM (
+      INSERT INTO ngc."User" (id, name, email, "createdAt", "updatedAt")
+      SELECT vu.id, vu.name, vu.email, vu."createdAt", vu."updatedAt"
+      FROM ngc."VerifiedUser" vu
+      LEFT JOIN ngc."User" u ON u.id = vu.id
+      WHERE u.id IS NULL
+      RETURNING id
+    )`
+
+    const count = result?.[0]?.count || '0'
+    logger.info('Created User records for orphaned VerifiedUsers', { count })
+
+    const remaining = await prisma.$queryRaw<
+      { count: bigint }[]
+    >`SELECT COUNT(*) FROM (
+      SELECT vu.id
+      FROM ngc."VerifiedUser" vu
+      LEFT JOIN ngc."User" u ON u.id = vu.id
+      WHERE u.id IS NULL
+    )`
+    logger.info('Remaining orphaned VerifiedUsers after migration', {
+      count: remaining?.[0]?.count?.toString() || '0',
+    })
+
+    process.exit(0)
+  } catch (e) {
+    logger.error(e)
+    process.exit(1)
+  }
+}
+
+main()

--- a/apps/server/src/features/groups/__tests__/create-group-participant.spec.ts
+++ b/apps/server/src/features/groups/__tests__/create-group-participant.spec.ts
@@ -17,7 +17,6 @@ import type { ParticipantInputCreateDto } from '../groups.validator.ts'
 import {
   CREATE_PARTICIPANT_ROUTE,
   createGroup,
-  joinGroup,
 } from './fixtures/groups.fixture.ts'
 
 describe('Given a NGC user', () => {
@@ -25,6 +24,7 @@ describe('Given a NGC user', () => {
   const url = CREATE_PARTICIPANT_ROUTE
 
   afterEach(async () => {
+    mswServer.resetHandlers()
     await Promise.all([
       prisma.groupAdministrator.deleteMany(),
       prisma.groupParticipant.deleteMany(),
@@ -48,11 +48,10 @@ describe('Given a NGC user', () => {
 
     describe('And group does exist', () => {
       let groupId: string
-      let groupName: string
 
       beforeEach(
         async () =>
-          ({ id: groupId, name: groupName } = await createGroup({
+          ({ id: groupId } = await createGroup({
             agent,
           }))
       )
@@ -175,7 +174,6 @@ describe('Given a NGC user', () => {
         const payload: ParticipantInputCreateDto = {
           userId: faker.string.uuid(),
           name: faker.person.fullName(),
-          email: faker.internet.email().toLocaleLowerCase(),
           simulation: getSimulationPayload(),
         }
 
@@ -208,9 +206,9 @@ describe('Given a NGC user', () => {
           user: {
             id: payload.userId,
             name: payload.name,
-            email: payload.email,
             createdAt: expect.any(Date),
             updatedAt: expect.any(Date),
+            email: null,
           },
           simulationId: payload.simulation.id,
           createdAt: expect.any(Date),
@@ -273,259 +271,9 @@ describe('Given a NGC user', () => {
           ],
           user: {
             name: payload.name,
-            email: payload.email,
             id: payload.userId,
+            email: null,
           },
-        })
-      })
-
-      describe('And leaving his/her email', () => {
-        test('Then it adds or updates contact in brevo', async () => {
-          const date = new Date()
-          const userId = faker.string.uuid()
-          const name = faker.person.fullName()
-          const email = faker.internet.email().toLocaleLowerCase()
-          const simulationPayload = getSimulationPayload({ date })
-          const { computedResults } = simulationPayload
-          const payload: ParticipantInputCreateDto = {
-            name,
-            email,
-            userId,
-            simulation: simulationPayload,
-          }
-
-          mswServer.use(
-            brevoSendEmail(),
-            brevoUpdateContact({
-              expectBody: {
-                email,
-                listIds: [30],
-                attributes: {
-                  USER_ID: userId,
-                  LAST_SIMULATION_DATE: date.toISOString(),
-                  ACTIONS_SELECTED_NUMBER: 0,
-                  LAST_SIMULATION_BILAN_FOOTPRINT: (
-                    computedResults.carbone.bilan / 1000
-                  ).toLocaleString('fr-FR', {
-                    maximumFractionDigits: 1,
-                  }),
-                  LAST_SIMULATION_TRANSPORTS_FOOTPRINT: (
-                    computedResults.carbone.categories.transport / 1000
-                  ).toLocaleString('fr-FR', {
-                    maximumFractionDigits: 1,
-                  }),
-                  LAST_SIMULATION_ALIMENTATION_FOOTPRINT: (
-                    computedResults.carbone.categories.alimentation / 1000
-                  ).toLocaleString('fr-FR', {
-                    maximumFractionDigits: 1,
-                  }),
-                  LAST_SIMULATION_LOGEMENT_FOOTPRINT: (
-                    computedResults.carbone.categories.logement / 1000
-                  ).toLocaleString('fr-FR', {
-                    maximumFractionDigits: 1,
-                  }),
-                  LAST_SIMULATION_DIVERS_FOOTPRINT: (
-                    computedResults.carbone.categories.divers / 1000
-                  ).toLocaleString('fr-FR', {
-                    maximumFractionDigits: 1,
-                  }),
-                  LAST_SIMULATION_SERVICES_FOOTPRINT: (
-                    computedResults.carbone.categories['services sociétaux'] /
-                    1000
-                  ).toLocaleString('fr-FR', {
-                    maximumFractionDigits: 1,
-                  }),
-                  LAST_SIMULATION_BILAN_WATER: Math.round(
-                    computedResults.eau.bilan / 365
-                  ).toString(),
-                  PRENOM: name,
-                },
-                updateEnabled: true,
-              },
-            })
-          )
-
-          await agent
-            .post(url.replace(':groupId', groupId))
-            .send(payload)
-            .expect(StatusCodes.CREATED)
-
-          await EventBus.flush()
-        })
-
-        test('Then it sends a join email', async () => {
-          const email = faker.internet.email().toLocaleLowerCase()
-          const userId = faker.string.uuid()
-          const payload: ParticipantInputCreateDto = {
-            email,
-            userId,
-            name: faker.person.fullName(),
-            simulation: getSimulationPayload(),
-          }
-
-          mswServer.use(
-            brevoSendEmail({
-              expectBody: {
-                to: [
-                  {
-                    name: email,
-                    email,
-                  },
-                ],
-                templateId: 58,
-                params: {
-                  GROUP_URL: `https://nosgestesclimat.fr/amis/resultats?groupId=${groupId}&mtm_campaign=email-automatise&mtm_kwd=groupe-invite-voir-classement`,
-                  SHARE_URL: `https://nosgestesclimat.fr/amis/invitation?groupId=${groupId}&mtm_campaign=email-automatise&mtm_kwd=groupe-invite-url-partage`,
-                  DELETE_URL: `https://nosgestesclimat.fr/amis/supprimer?groupId=${groupId}&userId=${userId}&mtm_campaign=email-automatise&mtm_kwd=groupe-invite-delete`,
-                  GROUP_NAME: groupName,
-                  NAME: payload.name,
-                },
-              },
-            }),
-            brevoUpdateContact()
-          )
-
-          await agent
-            .post(url.replace(':groupId', groupId))
-            .send(payload)
-            .expect(StatusCodes.CREATED)
-
-          await EventBus.flush()
-        })
-
-        describe('And incomplete simulation', () => {
-          test('Then it sends a continuation email', async () => {
-            const email = faker.internet.email().toLocaleLowerCase()
-            const userId = faker.string.uuid()
-            const payload: ParticipantInputCreateDto = {
-              email,
-              userId,
-              name: faker.person.fullName(),
-              simulation: getSimulationPayload({
-                progression: 0.5,
-              }),
-            }
-
-            mswServer.use(
-              brevoSendEmail({
-                expectBody: {
-                  to: [
-                    {
-                      name: email,
-                      email,
-                    },
-                  ],
-                  templateId: 102,
-                  params: {
-                    SIMULATION_URL: `https://nosgestesclimat.fr/simulateur/bilan?sid=${payload.simulation.id}&mtm_campaign=email-automatise&mtm_kwd=pause-test-en-cours`,
-                  },
-                },
-              })
-            )
-
-            await agent
-              .post(url.replace(':groupId', groupId))
-              .send(payload)
-              .expect(StatusCodes.CREATED)
-
-            await EventBus.flush()
-          })
-        })
-
-        describe('And custom user origin (preprod)', () => {
-          test('Then it sends a join email', async () => {
-            const email = faker.internet.email().toLocaleLowerCase()
-            const userId = faker.string.uuid()
-            const payload: ParticipantInputCreateDto = {
-              email,
-              userId,
-              name: faker.person.fullName(),
-              simulation: getSimulationPayload(),
-            }
-
-            mswServer.use(
-              brevoSendEmail({
-                expectBody: {
-                  to: [
-                    {
-                      name: email,
-                      email,
-                    },
-                  ],
-                  templateId: 58,
-                  params: {
-                    GROUP_URL: `https://preprod.nosgestesclimat.fr/amis/resultats?groupId=${groupId}&mtm_campaign=email-automatise&mtm_kwd=groupe-invite-voir-classement`,
-                    SHARE_URL: `https://preprod.nosgestesclimat.fr/amis/invitation?groupId=${groupId}&mtm_campaign=email-automatise&mtm_kwd=groupe-invite-url-partage`,
-                    DELETE_URL: `https://preprod.nosgestesclimat.fr/amis/supprimer?groupId=${groupId}&userId=${userId}&mtm_campaign=email-automatise&mtm_kwd=groupe-invite-delete`,
-                    GROUP_NAME: groupName,
-                    NAME: payload.name,
-                  },
-                },
-              }),
-              brevoUpdateContact()
-            )
-
-            await agent
-              .post(url.replace(':groupId', groupId))
-              .set('origin', 'https://preprod.nosgestesclimat.fr')
-              .send(payload)
-              .expect(StatusCodes.CREATED)
-
-            await EventBus.flush()
-          })
-        })
-
-        describe('And joining twice', () => {
-          let participant: Awaited<ReturnType<typeof joinGroup>>
-
-          beforeEach(async () => {
-            participant = await joinGroup({
-              agent,
-              groupId,
-              participant: {
-                email: faker.internet.email(),
-              },
-            })
-          })
-
-          test('Then it does not send email twice', async () => {
-            const {
-              id: _1,
-              createdAt: _2,
-              updatedAt: _3,
-              ...payload
-            } = participant
-
-            mswServer.use(brevoUpdateContact())
-
-            await agent
-              .post(url.replace(':groupId', groupId))
-              .send(payload)
-              .expect(StatusCodes.CREATED)
-
-            await EventBus.flush()
-          })
-
-          describe('And from another device', () => {
-            test('Then it does not send email twice', async () => {
-              const { email } = participant
-              const payload = {
-                email,
-                userId: faker.string.uuid(),
-                name: faker.person.fullName(),
-                simulation: getSimulationPayload(),
-              }
-
-              mswServer.use(brevoUpdateContact())
-
-              await agent
-                .post(url.replace(':groupId', groupId))
-                .send(payload)
-                .expect(StatusCodes.CREATED)
-
-              await EventBus.flush()
-            })
-          })
         })
       })
 

--- a/apps/server/src/features/groups/__tests__/delete-group-participant.spec.ts
+++ b/apps/server/src/features/groups/__tests__/delete-group-participant.spec.ts
@@ -2,10 +2,7 @@ import { faker } from '@faker-js/faker'
 import { StatusCodes } from 'http-status-codes'
 import supertest from 'supertest'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import {
-  brevoRemoveFromList,
-  brevoUpdateContact,
-} from '../../../adapters/brevo/__tests__/fixtures/server.fixture.ts'
+import { brevoUpdateContact } from '../../../adapters/brevo/__tests__/fixtures/server.fixture.ts'
 import { prisma } from '../../../adapters/prisma/client.ts'
 import * as prismaTransactionAdapter from '../../../adapters/prisma/transaction.ts'
 import app from '../../../app.ts'
@@ -155,129 +152,24 @@ describe('Given a NGC user', () => {
         })
       })
 
-      describe('And he did join leaving his/her email', () => {
-        let participantId: string
-        let userId: string
-        let participantUserEmail: string
+      describe('And group does exist And administrator left his/her email', () => {
+        let groupId: string
+        let groupCreatedAt: string
+        let administratorId: string
+        let administratorName: string
+        let administratorEmail: string
 
-        beforeEach(
-          async () =>
-            ({
-              id: participantId,
-              userId,
-              email: participantUserEmail,
-            } = await joinGroup({
-              agent,
-              groupId,
-              participant: {
-                email: faker.internet.email(),
-              },
-            }))
-        )
-
-        test('Then it updates group participant in brevo', async () => {
-          mswServer.use(
-            brevoRemoveFromList(30, {
-              expectBody: {
-                emails: [participantUserEmail],
-              },
-            })
-          )
-
-          await agent
-            .delete(
-              url
-                .replace(':groupId', groupId)
-                .replace(':participantId', participantId)
-                .replace(':userId', userId)
-            )
-            .expect(StatusCodes.NO_CONTENT)
-
-          await EventBus.flush()
-        })
-      })
-    })
-
-    describe('And group does exist And administrator left his/her email', () => {
-      let groupId: string
-      let groupCreatedAt: string
-      let administratorId: string
-      let administratorName: string
-      let administratorEmail: string
-
-      beforeEach(async () => {
-        const simulation = getSimulationPayload()
-        ;({
-          id: groupId,
-          createdAt: groupCreatedAt,
-          administrator: {
-            id: administratorId,
-            email: administratorEmail,
-            name: administratorName,
-          },
-        } = await createGroup({
-          agent,
-          group: {
+        beforeEach(async () => {
+          const simulation = getSimulationPayload()
+          ;({
+            id: groupId,
+            createdAt: groupCreatedAt,
             administrator: {
-              userId: faker.string.uuid(),
-              email: faker.internet.email(),
-              name: faker.person.fullName(),
+              id: administratorId,
+              email: administratorEmail,
+              name: administratorName,
             },
-            participants: [{ simulation }],
-          },
-        }))
-      })
-
-      describe('And he did join', () => {
-        let participantId: string
-        let userId: string
-
-        beforeEach(
-          async () =>
-            ({ id: participantId, userId } = await joinGroup({
-              agent,
-              groupId,
-            }))
-        )
-
-        test('Then it updates group administrator in brevo', async () => {
-          mswServer.use(
-            brevoUpdateContact({
-              expectBody: {
-                email: administratorEmail,
-                listIds: [29],
-                attributes: {
-                  USER_ID: administratorId,
-                  NUMBER_CREATED_GROUPS: 1,
-                  LAST_GROUP_CREATION_DATE: groupCreatedAt,
-                  NUMBER_CREATED_GROUPS_WITH_ONE_PARTICIPANT: 1,
-                  PRENOM: administratorName,
-                },
-                updateEnabled: true,
-              },
-            })
-          )
-
-          await agent
-            .delete(
-              url
-                .replace(':groupId', groupId)
-                .replace(':participantId', participantId)
-                .replace(':userId', userId)
-            )
-            .expect(StatusCodes.NO_CONTENT)
-
-          await EventBus.flush()
-        })
-      })
-    })
-
-    describe('And group does exist And administrator left his/her email but did not join', () => {
-      let groupId: string
-
-      beforeEach(
-        async () =>
-          ({ id: groupId } = await createGroup({
+          } = await createGroup({
             agent,
             group: {
               administrator: {
@@ -285,31 +177,94 @@ describe('Given a NGC user', () => {
                 email: faker.internet.email(),
                 name: faker.person.fullName(),
               },
+              participants: [{ simulation }],
             },
           }))
-      )
+        })
 
-      describe('And he did join', () => {
-        let participantId: string
-        let userId: string
+        describe('And he did join', () => {
+          let participantId: string
+          let userId: string
+
+          beforeEach(
+            async () =>
+              ({ id: participantId, userId } = await joinGroup({
+                agent,
+                groupId,
+              }))
+          )
+
+          test('Then it updates group administrator in brevo', async () => {
+            mswServer.use(
+              brevoUpdateContact({
+                expectBody: {
+                  email: administratorEmail,
+                  listIds: [29],
+                  attributes: {
+                    USER_ID: administratorId,
+                    NUMBER_CREATED_GROUPS: 1,
+                    LAST_GROUP_CREATION_DATE: groupCreatedAt,
+                    NUMBER_CREATED_GROUPS_WITH_ONE_PARTICIPANT: 1,
+                    PRENOM: administratorName,
+                  },
+                  updateEnabled: true,
+                },
+              })
+            )
+
+            await agent
+              .delete(
+                url
+                  .replace(':groupId', groupId)
+                  .replace(':participantId', participantId)
+                  .replace(':userId', userId)
+              )
+              .expect(StatusCodes.NO_CONTENT)
+
+            await EventBus.flush()
+          })
+        })
+      })
+
+      describe('And group does exist And administrator left his/her email but did not join', () => {
+        let groupId: string
 
         beforeEach(
           async () =>
-            ({ id: participantId, userId } = await joinGroup({
+            ({ id: groupId } = await createGroup({
               agent,
-              groupId,
+              group: {
+                administrator: {
+                  userId: faker.string.uuid(),
+                  email: faker.internet.email(),
+                  name: faker.person.fullName(),
+                },
+              },
             }))
         )
 
-        test('Then it updates group administrator in brevo', async () => {
-          await agent
-            .delete(
-              url
-                .replace(':groupId', groupId)
-                .replace(':participantId', participantId)
-                .replace(':userId', userId)
-            )
-            .expect(StatusCodes.NO_CONTENT)
+        describe('And he did join', () => {
+          let participantId: string
+          let userId: string
+
+          beforeEach(
+            async () =>
+              ({ id: participantId, userId } = await joinGroup({
+                agent,
+                groupId,
+              }))
+          )
+
+          test('Then it updates group administrator in brevo', async () => {
+            await agent
+              .delete(
+                url
+                  .replace(':groupId', groupId)
+                  .replace(':participantId', participantId)
+                  .replace(':userId', userId)
+              )
+              .expect(StatusCodes.NO_CONTENT)
+          })
         })
       })
     })

--- a/apps/server/src/features/groups/__tests__/delete-user-group.spec.ts
+++ b/apps/server/src/features/groups/__tests__/delete-user-group.spec.ts
@@ -16,7 +16,6 @@ import { getSimulationPayload } from '../../simulations/__tests__/fixtures/simul
 import {
   createGroup,
   DELETE_USER_GROUP_ROUTE,
-  joinGroup,
 } from './fixtures/groups.fixture.ts'
 
 describe('Given a NGC user', () => {
@@ -74,41 +73,6 @@ describe('Given a NGC user', () => {
             url.replace(':groupId', groupId).replace(':userId', administratorId)
           )
           .expect(StatusCodes.NO_CONTENT)
-      })
-
-      describe('And another participant joined leaving his email', () => {
-        let participantUserEmail: string
-
-        beforeEach(
-          async () =>
-            ({ email: participantUserEmail } = await joinGroup({
-              agent,
-              groupId,
-              participant: {
-                email: faker.internet.email(),
-              },
-            }))
-        )
-
-        test('Then it updates group participant in brevo', async () => {
-          mswServer.use(
-            brevoRemoveFromList(30, {
-              expectBody: {
-                emails: [participantUserEmail],
-              },
-            })
-          )
-
-          await agent
-            .delete(
-              url
-                .replace(':groupId', groupId)
-                .replace(':userId', administratorId)
-            )
-            .expect(StatusCodes.NO_CONTENT)
-
-          await EventBus.flush()
-        })
       })
     })
 

--- a/apps/server/src/features/groups/groups.repository.ts
+++ b/apps/server/src/features/groups/groups.repository.ts
@@ -6,10 +6,7 @@ import {
 } from '../../adapters/prisma/selection.ts'
 import type { Session } from '../../adapters/prisma/transaction.ts'
 import { createParticipantSimulation } from '../simulations/simulations.repository.ts'
-import {
-  createOrUpdateUser,
-  transferOwnershipToUser,
-} from '../users/users.repository.ts'
+import { createOrUpdateUser } from '../users/users.repository.ts'
 import type { UserParams } from '../users/users.validator.ts'
 import type {
   GroupCreateDto,
@@ -138,14 +135,9 @@ export const updateUserGroup = (
 
 export const createParticipantAndUser = async (
   { groupId }: GroupParams,
-  { userId, name, email, simulation: simulationDto }: ParticipantCreateDto,
+  { userId, name, simulation: simulationDto }: ParticipantCreateDto,
   { session }: { session: Session }
 ) => {
-  // Dedupe user
-  if (email) {
-    await transferOwnershipToUser({ user: { email, id: userId } }, { session })
-  }
-
   const existingParticipant = await session.groupParticipant.findUnique({
     where: {
       groupId_userId: {
@@ -161,7 +153,6 @@ export const createParticipantAndUser = async (
       id: userId,
       user: {
         name,
-        email,
       },
     },
     { session }

--- a/apps/server/src/features/organisations/__tests__/update-organisation.spec.ts
+++ b/apps/server/src/features/organisations/__tests__/update-organisation.spec.ts
@@ -401,7 +401,7 @@ describe('Given a NGC user', () => {
           .expect(StatusCodes.FORBIDDEN)
 
         expect(response.text).toEqual(
-          'Forbidden ! Cannot update administrator email. You must use the user route'
+          'Forbidden ! Cannot update administrator email.'
         )
       })
     })

--- a/apps/server/src/features/organisations/__tests__/update-organisation.spec.ts
+++ b/apps/server/src/features/organisations/__tests__/update-organisation.spec.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker'
 import { StatusCodes } from 'http-status-codes'
-import jwt from 'jsonwebtoken'
 import supertest from 'supertest'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
@@ -15,7 +14,6 @@ import { mswServer } from '../../../core/__tests__/fixtures/server.fixture.ts'
 import { EventBus } from '../../../core/event-bus/event-bus.ts'
 import logger from '../../../logger.ts'
 import { login } from '../../authentication/__tests__/fixtures/login.fixture.ts'
-import { createVerificationCode } from '../../authentication/__tests__/fixtures/verification-codes.fixture.ts'
 import { COOKIE_NAME } from '../../authentication/authentication.service.ts'
 import type { OrganisationUpdateDto } from '../organisations.validator.ts'
 import {
@@ -387,205 +385,24 @@ describe('Given a NGC user', () => {
         ;({ id: organisationId } = organisation)
       })
 
-      describe('And no verification code', () => {
-        test(`Then it returns a ${StatusCodes.FORBIDDEN} error`, async () => {
-          const payload: OrganisationUpdateDto = {
-            administrators: [
-              {
-                email: faker.internet.email(),
-              },
-            ],
-          }
+      test(`Then it returns a ${StatusCodes.FORBIDDEN} error`, async () => {
+        const payload: OrganisationUpdateDto = {
+          administrators: [
+            {
+              email: faker.internet.email(),
+            },
+          ],
+        }
 
-          const response = await agent
-            .put(url.replace(':organisationIdOrSlug', organisationId))
-            .set('cookie', cookie)
-            .send(payload)
-            .expect(StatusCodes.FORBIDDEN)
+        const response = await agent
+          .put(url.replace(':organisationIdOrSlug', organisationId))
+          .set('cookie', cookie)
+          .send(payload)
+          .expect(StatusCodes.FORBIDDEN)
 
-          expect(response.text).toEqual(
-            'Forbidden ! Cannot update administrator email without a verification code.'
-          )
-        })
-      })
-
-      describe('And invalid verification code', () => {
-        test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
-          const payload: OrganisationUpdateDto = {
-            administrators: [
-              {
-                email: faker.internet.email(),
-              },
-            ],
-          }
-
-          await agent
-            .put(url.replace(':organisationIdOrSlug', organisationId))
-            .set('cookie', cookie)
-            .query({
-              code: '42',
-            })
-            .send(payload)
-            .expect(StatusCodes.BAD_REQUEST)
-        })
-      })
-
-      describe('And verification code does not exist', () => {
-        test(`Then it returns a ${StatusCodes.FORBIDDEN} error`, async () => {
-          const payload: OrganisationUpdateDto = {
-            administrators: [
-              {
-                email: faker.internet.email(),
-              },
-            ],
-          }
-
-          const response = await agent
-            .put(url.replace(':organisationIdOrSlug', organisationId))
-            .set('cookie', cookie)
-            .query({
-              code: faker.number.int({ min: 100000, max: 999999 }).toString(),
-            })
-            .send(payload)
-            .expect(StatusCodes.FORBIDDEN)
-
-          expect(response.text).toEqual(
-            'Forbidden ! Invalid verification code.'
-          )
-        })
-      })
-
-      describe('And verification code does exist', () => {
-        let email: string
-        let code: string
-
-        beforeEach(async () => {
-          email = faker.internet.email().toLocaleLowerCase()
-          ;({ code } = await createVerificationCode({
-            agent,
-            verificationCode: { email },
-          }))
-        })
-
-        test(`Then it returns a ${StatusCodes.OK} response with the updated organisation and a new cookie`, async () => {
-          const administratorPayload = {
-            email,
-            name: faker.person.fullName(),
-            telephone: faker.phone.number(),
-            position: faker.person.jobDescriptor(),
-            optedInForCommunications: true,
-          }
-          const payload: OrganisationUpdateDto = {
-            administrators: [administratorPayload],
-          }
-
-          mswServer.use(brevoUpdateContact(), connectUpdateContact())
-
-          const response = await agent
-            .put(url.replace(':organisationIdOrSlug', organisationId))
-            .set('cookie', cookie)
-            .query({
-              code,
-            })
-            .send(payload)
-            .expect(StatusCodes.OK)
-
-          const [existingAdministrator] = organisation.administrators
-          expect(response.body).toEqual({
-            ...organisation,
-            administrators: [
-              {
-                ...existingAdministrator,
-                ...administratorPayload,
-                updatedAt: expect.any(String),
-              },
-            ],
-            updatedAt: expect.any(String),
-          })
-
-          // Cookies are kept in supertest
-          const [, newCookie] = response.headers['set-cookie']
-          const token = newCookie
-            .split(';')
-            .shift()
-            ?.replace('ngc_server_auth_jwt=', '')
-
-          expect(jwt.decode(token!)).toEqual({
-            userId,
-            email,
-            exp: expect.any(Number),
-            iat: expect.any(Number),
-          })
-        })
-
-        test('Then it adds or updates the contact in connect', async () => {
-          const administratorPayload = {
-            email,
-            name: faker.person.fullName(),
-            telephone: faker.phone.number(),
-            position: faker.person.jobDescriptor(),
-            optedInForCommunications: true,
-          }
-          const payload: OrganisationUpdateDto = {
-            administrators: [administratorPayload],
-          }
-
-          mswServer.use(
-            brevoUpdateContact(),
-            connectUpdateContact({
-              expectBody: {
-                email,
-                nom: administratorPayload.name,
-                fonction: administratorPayload.position,
-                source: 'Nos gestes Climat',
-              },
-            })
-          )
-
-          await agent
-            .put(url.replace(':organisationIdOrSlug', organisationId))
-            .set('cookie', cookie)
-            .query({
-              code,
-            })
-            .send(payload)
-            .expect(StatusCodes.OK)
-
-          await EventBus.flush()
-        })
-
-        describe('And Organisation does exist for the target email', () => {
-          beforeEach(async () => {
-            const { cookie } = await login({
-              agent,
-              verificationCode: { email },
-            })
-            await createOrganisation({ agent, cookie })
-          })
-
-          test(`Then it returns a ${StatusCodes.FORBIDDEN} error`, async () => {
-            const payload: OrganisationUpdateDto = {
-              administrators: [
-                {
-                  email,
-                },
-              ],
-            }
-
-            const response = await agent
-              .put(url.replace(':organisationIdOrSlug', organisationId))
-              .set('cookie', cookie)
-              .query({
-                code,
-              })
-              .send(payload)
-              .expect(StatusCodes.FORBIDDEN)
-
-            expect(response.text).toEqual(
-              'Forbidden ! This email already belongs to another organisation.'
-            )
-          })
-        })
+        expect(response.text).toEqual(
+          'Forbidden ! Cannot update administrator email. You must use the user route'
+        )
       })
     })
   })

--- a/apps/server/src/features/organisations/organisations.controller.ts
+++ b/apps/server/src/features/organisations/organisations.controller.ts
@@ -11,10 +11,6 @@ import { authentificationMiddleware } from '../../middlewares/authentificationMi
 import { rateLimitSameRequestMiddleware } from '../../middlewares/rateLimitSameRequestMiddleware.ts'
 import { validateRequest } from '../../middlewares/validateRequest.ts'
 import {
-  COOKIE_NAME,
-  getCookieOptions,
-} from '../authentication/authentication.service.ts'
-import {
   createPollSimulation,
   fetchPublicPollSimulations,
 } from '../simulations/simulations.service.ts'
@@ -106,19 +102,13 @@ router
     authentificationMiddleware(),
     validateRequest(OrganisationUpdateValidator),
     async (req, res) => {
-      const { body, params, query, user } = req
+      const { body, params, user } = req
       try {
-        const { organisation, token } = await updateOrganisation({
+        const { organisation } = await updateOrganisation({
           params,
           organisationDto: body,
-          code: query.code,
           user: user!,
         })
-
-        if (token) {
-          const origin = req.get('origin') || config.app.origin
-          res.cookie(COOKIE_NAME, token, getCookieOptions(origin))
-        }
 
         return res.status(StatusCodes.OK).json(organisation)
       } catch (err) {

--- a/apps/server/src/features/organisations/organisations.repository.ts
+++ b/apps/server/src/features/organisations/organisations.repository.ts
@@ -13,6 +13,7 @@ import type { Session } from '../../adapters/prisma/transaction.ts'
 import type { PaginationQuery } from '../../core/pagination.ts'
 import type { SimulationParams } from '../simulations/simulations.validator.ts'
 import { ComputedResultSchema } from '../simulations/simulations.validator.ts'
+import { createOrUpdateVerifiedUser } from '../users/users.repository.ts'
 import type {
   OrganisationCreateDto,
   OrganisationParams,
@@ -171,28 +172,19 @@ export const createOrganisationAndAdministrator = async (
   { userId, email }: NonNullable<Request['user']>,
   { session }: { session: Session }
 ) => {
-  // upsert administrator
-  const administrator = await session.verifiedUser.upsert({
-    where: {
-      email,
+  const { user: administrator } = await createOrUpdateVerifiedUser(
+    {
+      id: { userId, email },
+      user: {
+        name: administratorName,
+        position,
+        telephone,
+        optedInForCommunications,
+      },
+      select: defaultVerifiedUserSelection,
     },
-    create: {
-      email,
-      id: userId,
-      name: administratorName,
-      position,
-      telephone,
-      optedInForCommunications,
-    },
-    update: {
-      id: userId,
-      name: administratorName,
-      position,
-      telephone,
-      optedInForCommunications,
-    },
-    select: defaultVerifiedUserSelection,
-  })
+    { session }
+  )
 
   const slug = await findUniqueOrganisationSlug(name, {
     session,
@@ -260,21 +252,21 @@ export const updateAdministratorOrganisation = async (
       },
     ] = administrators
 
-    // update administrator
-    administrator = await session.verifiedUser.update({
-      where: {
-        email: userEmail,
+    const { user: adminUser } = await createOrUpdateVerifiedUser(
+      {
+        id: { userId: user.userId, email: userEmail },
+        user: {
+          name: administratorName,
+          email,
+          position,
+          telephone,
+          optedInForCommunications,
+        },
+        select: defaultVerifiedUserSelection,
       },
-      data: {
-        id: user.userId,
-        name: administratorName,
-        email,
-        position,
-        telephone,
-        optedInForCommunications,
-      },
-      select: defaultVerifiedUserSelection,
-    })
+      { session }
+    )
+    administrator = adminUser
 
     if (email) {
       user.email = email

--- a/apps/server/src/features/organisations/organisations.service.ts
+++ b/apps/server/src/features/organisations/organisations.service.ts
@@ -23,10 +23,7 @@ import {
   isPrismaErrorUniqueConstraintFailed,
 } from '../../core/typeguards/isPrismaError.ts'
 import logger from '../../logger.ts'
-import {
-  createToken,
-  verifyCode,
-} from '../authentication/authentication.service.ts'
+import { createToken } from '../authentication/authentication.service.ts'
 import type { JobParams } from '../jobs/jobs.repository.ts'
 import { JobKind } from '../jobs/jobs.repository.ts'
 import {
@@ -159,35 +156,18 @@ export const createOrganisation = async ({
 export const updateOrganisation = async ({
   params,
   organisationDto,
-  code,
   user,
 }: {
   params: OrganisationParams
   organisationDto: OrganisationUpdateDto
-  code?: string
   user: NonNullable<Request['user']>
 }) => {
   let token: string | undefined
   const { administrators: [{ email }] = [{}] } = organisationDto
   if (email && email !== user.email) {
-    if (!code) {
-      throw new ForbiddenException(
-        'Forbidden ! Cannot update administrator email without a verification code.'
-      )
-    }
-
-    try {
-      await verifyCode({
-        ...user,
-        code,
-        email,
-      })
-    } catch (e) {
-      if (e instanceof EntityNotFoundException) {
-        throw new ForbiddenException('Forbidden ! Invalid verification code.')
-      }
-      throw e
-    }
+    throw new ForbiddenException(
+      'Forbidden ! Cannot update administrator email. You must use the user route'
+    )
   }
 
   try {

--- a/apps/server/src/features/organisations/organisations.service.ts
+++ b/apps/server/src/features/organisations/organisations.service.ts
@@ -166,7 +166,7 @@ export const updateOrganisation = async ({
   const { administrators: [{ email }] = [{}] } = organisationDto
   if (email && email !== user.email) {
     throw new ForbiddenException(
-      'Forbidden ! Cannot update administrator email. You must use the user route'
+      'Forbidden ! Cannot update administrator email.'
     )
   }
 

--- a/apps/server/src/features/users/users.repository.ts
+++ b/apps/server/src/features/users/users.repository.ts
@@ -7,7 +7,6 @@ import type {
   RequestOptionsOrNull,
   Session,
 } from '../../adapters/prisma/transaction.ts'
-import type { UserUpdateDto } from './users.validator.ts'
 
 /**
  * Legacy migration function. Finds all anonymous users sharing the same
@@ -364,18 +363,36 @@ export const createOrUpdateUser = async <
   }
 }
 
+type VerifiedUserPayload = {
+  email?: string | undefined
+  name?: string | null | undefined
+  position?: string | null | undefined
+  telephone?: string | null | undefined
+  optedInForCommunications?: boolean | undefined
+}
+
 export const createOrUpdateVerifiedUser = async <
   Select extends Prisma.VerifiedUserSelect = { id: true },
 >(
   {
     id: { userId, email },
-    user: { name, email: newEmail },
+    user: {
+      email: newEmail,
+      name,
+      position,
+      telephone,
+      optedInForCommunications,
+    },
     select = { email: true } as Select,
-  }: { id: NonNullable<Request['user']>; user: UserUpdateDto; select?: Select },
+  }: {
+    id: NonNullable<Request['user']>
+    user: VerifiedUserPayload
+    select?: Select
+  },
   { session }: { session: Session }
 ) => {
   const existingUser = await fetchVerifiedUser({ email }, { session })
-
+  const userData = { name, position, telephone, optedInForCommunications }
   const [user] = await Promise.all([
     existingUser
       ? session.verifiedUser.update({
@@ -384,7 +401,7 @@ export const createOrUpdateVerifiedUser = async <
           },
           data: {
             id: userId,
-            name,
+            ...userData,
             ...(newEmail ? { email: newEmail } : {}),
           },
           select,
@@ -393,7 +410,7 @@ export const createOrUpdateVerifiedUser = async <
           data: {
             id: userId,
             email: newEmail || email,
-            name,
+            ...userData,
           },
           select,
         }),
@@ -403,7 +420,7 @@ export const createOrUpdateVerifiedUser = async <
         id: userId,
         user: {
           email: newEmail || email,
-          name,
+          name: userData.name,
         },
       },
       { session }


### PR DESCRIPTION
We add a script to create a User for all VerifiedUser. The next step will be to add a FK constraint. 

We prevent organisation to create a VerifiedUser even if no User is attached.

Besides, we remove the following possibility / feature, that have been removed from the next app :
- Leaving the email when joining a group
- Use a code to update user email from organisation route
 
---
_Details_
- Add NGC-3379-20260513 migration to create User records for orphaned VerifiedUsers
- Remove email from participant creation and deduplication logic
- Refactor organisation repository to use createOrUpdateVerifiedUser
- Remove code verification requirement for admin email changes
- Update createOrUpdateVerifiedUser to accept flexible user payload

fix NGC-3379