### PR TITLE
✨ Feature flag overrides via URL parameters + E2E fixture

### DIFF
--- a/apps/site/e2e/fixtures/feature-flags.ts
+++ b/apps/site/e2e/fixtures/feature-flags.ts
@@ -1,0 +1,56 @@
+import { test as base, type Page } from '@playwright/test'
+
+import { FF_COOKIE_NAME } from '@/services/feature-flags/constants'
+import type { FeatureFlagName } from '@/services/feature-flags/flags'
+
+const DEFAULT_FLAGS = {
+  'actions-v2': false,
+} satisfies Record<FeatureFlagName, boolean>
+
+export class FeatureFlags {
+  constructor(private page: Page) {}
+
+  async set(flags: Record<string, boolean>) {
+    await this.page.context().addCookies([
+      {
+        name: FF_COOKIE_NAME,
+        value: JSON.stringify(flags),
+        path: '/',
+        sameSite: 'Lax' as const,
+      },
+    ])
+  }
+
+  async enable(flag: string) {
+    await this.set({ ...(await this.#read()), [flag]: true })
+  }
+
+  async disable(flag: string) {
+    await this.set({ ...(await this.#read()), [flag]: false })
+  }
+
+  async #read(): Promise<Record<string, boolean>> {
+    const cookies = await this.page.context().cookies()
+    const ffCookie = cookies.find((c) => c.name === FF_COOKIE_NAME)
+    if (!ffCookie) return {}
+    try {
+      return JSON.parse(ffCookie.value)
+    } catch {
+      return {}
+    }
+  }
+}
+
+interface FeatureFlagFixtures {
+  featureFlags: FeatureFlags
+}
+
+const test = base.extend<FeatureFlagFixtures>({
+  featureFlags: async ({ page }, use) => {
+    const featureFlags = new FeatureFlags(page)
+    await featureFlags.set({ ...DEFAULT_FLAGS })
+    await use(featureFlags)
+  },
+})
+
+export { test }

--- a/apps/site/e2e/fixtures/index.ts
+++ b/apps/site/e2e/fixtures/index.ts
@@ -1,5 +1,6 @@
 import { mergeTests } from '@playwright/test'
 import { test as cookieBannerTest } from '../fixtures/cookie-banner'
+import { test as featureFlagsTest } from '../fixtures/feature-flags'
 import { test as groupTest } from '../fixtures/groups'
 import { test as ngcTest } from '../fixtures/ngc-test'
 import { test as organisationTest } from '../fixtures/organisations'
@@ -11,6 +12,7 @@ export const test = mergeTests(
   groupTest,
   ngcTest,
   cookieBannerTest,
+  featureFlagsTest,
   organisationTest,
   userAccountTest,
   pollTest

--- a/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/actions/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/actions/page.tsx
@@ -7,7 +7,7 @@ import { throwNextError } from '@/helpers/server/error'
 import { getSimulations } from '@/helpers/server/model/simulations'
 import { getAuthUser } from '@/helpers/server/model/user'
 import type { Locale } from '@/i18nConfig'
-import { posthogClient } from '@/services/tracking/posthogServer'
+import { getFeatureFlag } from '@/services/feature-flags/getFeatureFlag'
 import type { DefaultPageProps } from '@/types'
 import { actions } from '@nosgestesclimat/core/features/actions/data/actions/index'
 import { themes } from '@nosgestesclimat/core/features/actions/data/themes/index'
@@ -18,7 +18,7 @@ export default async function MonEspaceActionsPage({
 }: DefaultPageProps) {
   const { locale } = await params
   const user = await throwNextError(getAuthUser)
-  const flag = await posthogClient.getFeatureFlag('actions-v2', user.id)
+  const flag = await getFeatureFlag('actions-v2', user.id)
 
   return (
     <div className="flex flex-col">

--- a/apps/site/src/app/[locale]/(server)/(large)/actions/[slug]/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/actions/[slug]/page.tsx
@@ -14,7 +14,7 @@ import { getServerTranslation } from '@/helpers/getServerTranslation'
 import { t } from '@/helpers/metadata/fakeMetadataT'
 import { getMetadataObject } from '@/helpers/metadata/getMetadataObject'
 import { getUser } from '@/helpers/server/dal/user'
-import { posthogClient } from '@/services/tracking/posthogServer'
+import { getFeatureFlag } from '@/services/feature-flags/getFeatureFlag'
 import type { DefaultPageProps } from '@/types'
 import { actions } from '@nosgestesclimat/core/features/actions/data/actions/index'
 import type { Theme } from '@nosgestesclimat/core/features/actions/types/theme'
@@ -60,7 +60,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 export default async function ActionPage({ params }: Props) {
   const { locale, slug } = await params
   const user = await getUser()
-  const flag = await posthogClient.getFeatureFlag('actions-v2', user.id)
+  const flag = await getFeatureFlag('actions-v2', user.id)
 
   if (!flag) notFound()
 

--- a/apps/site/src/app/[locale]/(server)/(large)/fin/actions/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/fin/actions/page.tsx
@@ -4,7 +4,7 @@ import type { AppUser } from '@/helpers/server/dal/user'
 import { getUser } from '@/helpers/server/dal/user'
 import { getSimulations } from '@/helpers/server/model/simulations'
 import type { Locale } from '@/i18nConfig'
-import { posthogClient } from '@/services/tracking/posthogServer'
+import { getFeatureFlag } from '@/services/feature-flags/getFeatureFlag'
 import type { DefaultPageProps } from '@/types'
 import { actions } from '@nosgestesclimat/core/features/actions/data/actions/index'
 import { themes } from '@nosgestesclimat/core/features/actions/data/themes/index'
@@ -14,7 +14,7 @@ export default async function ResultatsActionsPage({
 }: DefaultPageProps) {
   const { locale } = await params
   const user = await getUser()
-  const flag = await posthogClient.getFeatureFlag('actions-v2', user.id)
+  const flag = await getFeatureFlag('actions-v2', user.id)
 
   if (!flag) {
     return <LegacyResultatsActionsPage user={user} locale={locale} />

--- a/apps/site/src/helpers/server/error.ts
+++ b/apps/site/src/helpers/server/error.ts
@@ -36,8 +36,8 @@ export class TooManyRequestsError extends Error {
 }
 
 export class InternalServerError extends Error {
-  constructor() {
-    super('Internal Server Error')
+  constructor(message = 'Internal Server Error') {
+    super(message)
 
     this.name = 'InternalServerError'
   }

--- a/apps/site/src/hooks/useFeatureFlag.ts
+++ b/apps/site/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import { FF_COOKIE_NAME } from '@/services/feature-flags/constants'
+import type { FeatureFlagName } from '@/services/feature-flags/flags'
+import { parseFeatureFlagCookie } from '@/services/feature-flags/urlParams'
+import { getClientCookie } from '@/utils/cookie'
+import posthog from 'posthog-js'
+import { useEffect, useState } from 'react'
+
+function resolveFlagValue(flag: FeatureFlagName): boolean | undefined {
+  const raw = getClientCookie(FF_COOKIE_NAME)
+  const overrides = parseFeatureFlagCookie(raw)
+  if (flag in overrides) return overrides[flag]
+  return posthog?.isFeatureEnabled(flag)
+}
+
+export function useFeatureFlag(flag: FeatureFlagName): boolean | undefined {
+  const [value, setValue] = useState<boolean | undefined>(() =>
+    resolveFlagValue(flag)
+  )
+
+  useEffect(() => {
+    const unsubscribe = posthog?.onFeatureFlags(() =>
+      setValue(resolveFlagValue(flag))
+    )
+    return () => {
+      unsubscribe?.()
+    }
+  }, [flag])
+
+  return value
+}

--- a/apps/site/src/middlewares/featureFlagMiddleware.ts
+++ b/apps/site/src/middlewares/featureFlagMiddleware.ts
@@ -1,0 +1,34 @@
+import { FF_COOKIE_NAME } from '@/services/feature-flags/constants'
+import {
+  parseFeatureFlagCookie,
+  parseFeatureFlagParams,
+  stripFeatureFlagParams,
+} from '@/services/feature-flags/urlParams'
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+const secure =
+  new URL(process.env.NEXT_PUBLIC_SITE_URL!).hostname !== 'localhost'
+
+export async function featureFlagMiddleware(
+  request: NextRequest,
+  next: (req: NextRequest) => NextResponse | Promise<NextResponse>
+): Promise<NextResponse> {
+  const incoming = parseFeatureFlagParams(request.nextUrl.searchParams)
+  if (!incoming) return next(request)
+
+  const existing = parseFeatureFlagCookie(
+    request.cookies.get(FF_COOKIE_NAME)?.value
+  )
+  const merged = { ...existing, ...incoming }
+
+  const response = NextResponse.redirect(
+    stripFeatureFlagParams(request.nextUrl)
+  )
+  response.cookies.set(FF_COOKIE_NAME, JSON.stringify(merged), {
+    secure,
+    sameSite: 'lax',
+    path: '/',
+  })
+  return response
+}

--- a/apps/site/src/proxy.ts
+++ b/apps/site/src/proxy.ts
@@ -1,9 +1,12 @@
 import type { NextRequest, ProxyConfig } from 'next/server'
 import { userMiddleware } from './helpers/server/dal/middleware'
+import { featureFlagMiddleware } from './middlewares/featureFlagMiddleware'
 import i18nMiddleware from './middlewares/i18nMiddleware'
 
 export async function proxy(request: NextRequest) {
-  return await userMiddleware(request, i18nMiddleware)
+  return await featureFlagMiddleware(request, (req) =>
+    userMiddleware(req, i18nMiddleware)
+  )
 }
 
 export const config: ProxyConfig = {

--- a/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
+++ b/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseFeatureFlagCookie,
+  parseFeatureFlagParams,
+  stripFeatureFlagParams,
+} from '../urlParams'
+
+describe('parseFeatureFlagParams', () => {
+  it('returns null when no ff_ params are present', () => {
+    expect(parseFeatureFlagParams(new URLSearchParams('?sid=123'))).toBeNull()
+  })
+
+  it('parses a single truthy flag', () => {
+    expect(
+      parseFeatureFlagParams(new URLSearchParams('?ff_my-flag=true'))
+    ).toEqual({ 'my-flag': true })
+  })
+
+  it('parses a single falsy flag', () => {
+    expect(
+      parseFeatureFlagParams(new URLSearchParams('?ff_my-flag=false'))
+    ).toEqual({ 'my-flag': false })
+  })
+
+  it('ignores values other than true/false', () => {
+    expect(
+      parseFeatureFlagParams(new URLSearchParams('?ff_flag=yes'))
+    ).toBeNull()
+  })
+})
+
+describe('stripFeatureFlagParams', () => {
+  it('removes ff_ params while keeping others', () => {
+    expect(
+      stripFeatureFlagParams(
+        new URL('https://example.com/page?ff_flag=true&sid=123')
+      ).search
+    ).toBe('?sid=123')
+  })
+})
+
+describe('parseFeatureFlagCookie', () => {
+  it('parses a valid JSON cookie value', () => {
+    expect(parseFeatureFlagCookie('{"actions-v2":true}')).toEqual({
+      'actions-v2': true,
+    })
+  })
+
+  it('returns empty object for undefined, empty, or malformed input', () => {
+    expect(parseFeatureFlagCookie(undefined)).toEqual({})
+    expect(parseFeatureFlagCookie('')).toEqual({})
+    expect(parseFeatureFlagCookie('not-json')).toEqual({})
+  })
+})

--- a/apps/site/src/services/feature-flags/constants.ts
+++ b/apps/site/src/services/feature-flags/constants.ts
@@ -1,0 +1,2 @@
+export const FF_COOKIE_NAME = 'ngc_ff_overrides'
+export const FF_PARAM_PREFIX = 'ff_'

--- a/apps/site/src/services/feature-flags/flags.ts
+++ b/apps/site/src/services/feature-flags/flags.ts
@@ -1,0 +1,3 @@
+export const FEATURE_FLAGS = ['actions-v2'] as const
+
+export type FeatureFlagName = (typeof FEATURE_FLAGS)[number]

--- a/apps/site/src/services/feature-flags/getFeatureFlag.ts
+++ b/apps/site/src/services/feature-flags/getFeatureFlag.ts
@@ -1,0 +1,17 @@
+import { posthogClient } from '@/services/tracking/posthogServer'
+import { cookies } from 'next/headers'
+import { FF_COOKIE_NAME } from './constants'
+import type { FeatureFlagName } from './flags'
+import { parseFeatureFlagCookie } from './urlParams'
+
+export async function getFeatureFlag(
+  flag: FeatureFlagName,
+  userId: string
+): Promise<string | boolean | undefined> {
+  const cookieStore = await cookies()
+  const overrides = parseFeatureFlagCookie(
+    cookieStore.get(FF_COOKIE_NAME)?.value
+  )
+  if (flag in overrides) return overrides[flag]
+  return posthogClient.getFeatureFlag(flag, userId)
+}

--- a/apps/site/src/services/feature-flags/urlParams.ts
+++ b/apps/site/src/services/feature-flags/urlParams.ts
@@ -1,0 +1,57 @@
+import { FF_PARAM_PREFIX } from './constants'
+import type { FeatureFlagName } from './flags'
+
+/**
+ * Extracts feature flag overrides from URL search parameters.
+ *
+ * Recognises params with the `FF_PARAM_PREFIX` prefix (e.g. `?ff_actions-v2=true`).
+ * Returns `null` when no valid overrides are present.
+ *
+ * @example `?ff_actions-v2=true&ff_new-feature=false` → `{ 'actions-v2': true, 'new-feature': false }`
+ */
+export function parseFeatureFlagParams(
+  searchParams: URLSearchParams
+): Record<string, boolean> | null {
+  const overrides: Record<string, boolean> = {}
+  for (const [key, value] of searchParams.entries()) {
+    if (!key.startsWith(FF_PARAM_PREFIX)) continue
+    const flagName = key.slice(FF_PARAM_PREFIX.length)
+    if (value === 'true') overrides[flagName] = true
+    else if (value === 'false') overrides[flagName] = false
+  }
+  return Object.keys(overrides).length > 0 ? overrides : null
+}
+
+/**
+ * Returns a copy of the given URL with all feature flag query params removed.
+ */
+export function stripFeatureFlagParams(url: URL): URL {
+  const cleaned = new URL(url)
+  for (const key of [...cleaned.searchParams.keys()]) {
+    if (key.startsWith(FF_PARAM_PREFIX)) cleaned.searchParams.delete(key)
+  }
+  return cleaned
+}
+
+/**
+ * Parses the raw feature flag cookie value into a typed overrides map.
+ * Returns an empty record for malformed, missing, or non-object input.
+ */
+export function parseFeatureFlagCookie(
+  raw: string | undefined
+): Partial<Record<FeatureFlagName, boolean>> {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return {}
+    }
+    return parsed
+  } catch {
+    return {}
+  }
+}

--- a/apps/site/src/utils/__tests__/cookie.test.ts
+++ b/apps/site/src/utils/__tests__/cookie.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { getClientCookie } from '../cookie'
+
+describe('getClientCookie', () => {
+  it('returns undefined when document is not available (SSR)', () => {
+    expect(getClientCookie('test')).toBeUndefined()
+  })
+
+  it('returns undefined for a missing cookie', () => {
+    Object.defineProperty(document, 'cookie', {
+      value: 'other=foo',
+      writable: true,
+    })
+    expect(getClientCookie('missing')).toBeUndefined()
+  })
+
+  it('returns a plain value', () => {
+    Object.defineProperty(document, 'cookie', {
+      value: 'myCookie=hello',
+      writable: true,
+    })
+    expect(getClientCookie('myCookie')).toBe('hello')
+  })
+
+  it('returns a URL-encoded value', () => {
+    Object.defineProperty(document, 'cookie', {
+      value: 'myCookie=%7B%22key%22%3Atrue%7D',
+      writable: true,
+    })
+    expect(getClientCookie('myCookie')).toBe('{"key":true}')
+  })
+
+  it('returns the first match when multiple cookies are present', () => {
+    Object.defineProperty(document, 'cookie', {
+      value: 'a=1; b=2; target=found; c=3',
+      writable: true,
+    })
+    expect(getClientCookie('target')).toBe('found')
+  })
+
+  it('escapes special regex characters in the cookie name', () => {
+    Object.defineProperty(document, 'cookie', {
+      value: 'some.cookie[name]=escaped',
+      writable: true,
+    })
+    expect(getClientCookie('some.cookie[name]')).toBe('escaped')
+  })
+
+  it('handles a cookie name that is a prefix of another cookie name', () => {
+    Object.defineProperty(document, 'cookie', {
+      value: 'ff=short; ff_longer=other',
+      writable: true,
+    })
+    expect(getClientCookie('ff')).toBe('short')
+  })
+})

--- a/apps/site/src/utils/cookie.ts
+++ b/apps/site/src/utils/cookie.ts
@@ -1,0 +1,11 @@
+import { InternalServerError } from '@/helpers/server/error'
+
+export function getClientCookie(name: string): string | undefined {
+  if (typeof document === 'undefined')
+    throw new InternalServerError(
+      'getClientCookie must be called on the client (hook)'
+    )
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = new RegExp(`(?:^|; )${escaped}=([^;]*)`).exec(document.cookie)
+  return match ? decodeURIComponent(match[1]) : undefined
+}


### PR DESCRIPTION
## What

Centralised feature flag system with URL-based overrides and an E2E Playwright fixture.

### Feature flag service (`src/services/feature-flags/`)

- **`flags.ts`** — single source of truth for all feature flags (`FEATURE_FLAGS` const + `FeatureFlagName` type). Removing an entry causes TypeScript errors everywhere it was referenced.
- **`getFeatureFlag()`** — server-side resolution: checks `ngc_ff_overrides` cookie first, falls back to `posthog-node`.
- **`useFeatureFlag()`** — client-side hook: checks the cookie first, falls back to `posthog.isFeatureEnabled()` + `onFeatureFlags` for reactivity.

### URL parameter overrides (`src/middlewares/featureFlagMiddleware.ts`)

POs can enable/disable flags via URL: `?ff_actions-v2=true&ff_new-feature=false`

- The middleware intercepts `ff_*` params, merges with existing cookie overrides, and redirects to a clean URL.
- Non-`httpOnly` cookie — readable on both server and client without round-trips.

### E2E fixture (`e2e/fixtures/feature-flags.ts`)

- Features flag can be enable or disabled by default (`DEFAULT_FLAGS`)
- `featureFlags.enable(flag)` / `featureFlags.disable(flag)` for per-test overrides.

### How to test

```bash
# Enable the new action page
/fin/actions?ff_actions-v2=true

# Multiple flags
/fin/actions?ff_actions-v2=true&ff_new-feature=false

# In E2E tests
featureFlags.enable(actions-v2)
await page.goto(/fin/actions)
```