### PR TITLE
feat: support variant feature flags (A/B tests)

### DIFF
--- a/apps/site/e2e/fixtures/feature-flags.ts
+++ b/apps/site/e2e/fixtures/feature-flags.ts
@@ -8,6 +8,7 @@ const DOMAIN = new URL(process.env.NEXT_PUBLIC_SITE_URL!).hostname
 const DEFAULT_FLAGS = {
   'actions-v2': false,
   'mode-scolaire': true,
+  'ab-test-tranche': 'control',
 } satisfies DefaultFlagValues
 
 export class FeatureFlags {

--- a/apps/site/e2e/fixtures/feature-flags.ts
+++ b/apps/site/e2e/fixtures/feature-flags.ts
@@ -1,7 +1,7 @@
 import { test as base, type Page } from '@playwright/test'
 
 import { FF_COOKIE_NAME } from '@/services/feature-flags/constants'
-import type { FeatureFlagName } from '@/services/feature-flags/flags'
+import type { DefaultFlagValues } from '@/services/feature-flags/flags'
 
 const DOMAIN = new URL(process.env.NEXT_PUBLIC_SITE_URL!).hostname
 
@@ -9,7 +9,7 @@ const DEFAULT_FLAGS = {
   'actions-v2': false,
   'mode-scolaire': true,
   'ab-test-tranche': 'control',
-} satisfies Record<FeatureFlagName, string | boolean>
+} satisfies DefaultFlagValues
 
 export class FeatureFlags {
   constructor(private page: Page) {}

--- a/apps/site/e2e/fixtures/feature-flags.ts
+++ b/apps/site/e2e/fixtures/feature-flags.ts
@@ -8,12 +8,13 @@ const DOMAIN = new URL(process.env.NEXT_PUBLIC_SITE_URL!).hostname
 const DEFAULT_FLAGS = {
   'actions-v2': false,
   'mode-scolaire': true,
-} satisfies Record<FeatureFlagName, boolean>
+  'ab-test-tranche': 'control',
+} satisfies Record<FeatureFlagName, string | boolean>
 
 export class FeatureFlags {
   constructor(private page: Page) {}
 
-  async set(flags: Record<string, boolean>) {
+  async set(flags: Record<string, string | boolean>) {
     await this.page.context().addCookies([
       {
         name: FF_COOKIE_NAME,
@@ -33,7 +34,7 @@ export class FeatureFlags {
     await this.set({ ...(await this.#read()), [flag]: false })
   }
 
-  async #read(): Promise<Record<string, boolean>> {
+  async #read(): Promise<Record<string, string | boolean>> {
     const cookies = await this.page.context().cookies()
     const ffCookie = cookies.find((c) => c.name === FF_COOKIE_NAME)
     if (!ffCookie) return {}

--- a/apps/site/e2e/fixtures/feature-flags.ts
+++ b/apps/site/e2e/fixtures/feature-flags.ts
@@ -8,7 +8,6 @@ const DOMAIN = new URL(process.env.NEXT_PUBLIC_SITE_URL!).hostname
 const DEFAULT_FLAGS = {
   'actions-v2': false,
   'mode-scolaire': true,
-  'ab-test-tranche': 'control',
 } satisfies DefaultFlagValues
 
 export class FeatureFlags {

--- a/apps/site/src/hooks/useFeatureFlag.ts
+++ b/apps/site/src/hooks/useFeatureFlag.ts
@@ -1,39 +1,27 @@
 'use client'
 
 import { FF_COOKIE_NAME } from '@/services/feature-flags/constants'
-import type { FeatureFlagName } from '@/services/feature-flags/flags'
+import type { FeatureFlagName, FeatureFlagValue } from '@/services/feature-flags/flags'
 import { parseFeatureFlagCookie } from '@/services/feature-flags/urlParams'
 import { getClientCookie } from '@/utils/cookie'
 import posthog from 'posthog-js'
 import { useEffect, useState } from 'react'
 
-type VariantFlagResult = string | boolean | undefined
+type Maybe<T> = T | undefined
 
-function resolveFlagValue(
-  flag: FeatureFlagName
-): VariantFlagResult {
+function resolveFlagValue<K extends FeatureFlagName>(
+  flag: K
+): Maybe<FeatureFlagValue<K>> {
   const raw = getClientCookie(FF_COOKIE_NAME)
   const overrides = parseFeatureFlagCookie(raw)
-  if (flag in overrides) return overrides[flag]
-  return posthog?.getFeatureFlag(flag)
+  if (flag in overrides) return overrides[flag] as FeatureFlagValue<K>
+  return posthog?.getFeatureFlag(flag) as Maybe<FeatureFlagValue<K>>
 }
 
-export function useFeatureFlag(
-  flag: 'actions-v2'
-): boolean | undefined
-export function useFeatureFlag(
-  flag: 'mode-scolaire'
-): boolean | undefined
-export function useFeatureFlag(
-  flag: 'ab-test-tranche'
-): 'control' | 'test' | undefined
-export function useFeatureFlag(
-  flag: FeatureFlagName
-): VariantFlagResult
-export function useFeatureFlag(
-  flag: FeatureFlagName
-): VariantFlagResult {
-  const [value, setValue] = useState<VariantFlagResult>(() =>
+export function useFeatureFlag<K extends FeatureFlagName>(
+  flag: K
+): Maybe<FeatureFlagValue<K>> {
+  const [value, setValue] = useState<Maybe<FeatureFlagValue<K>>>(() =>
     resolveFlagValue(flag)
   )
 

--- a/apps/site/src/hooks/useFeatureFlag.ts
+++ b/apps/site/src/hooks/useFeatureFlag.ts
@@ -7,21 +7,19 @@ import { getClientCookie } from '@/utils/cookie'
 import posthog from 'posthog-js'
 import { useEffect, useState } from 'react'
 
-type Maybe<T> = T | undefined
-
 function resolveFlagValue<K extends FeatureFlagName>(
   flag: K
-): Maybe<FeatureFlagValue<K>> {
+): FeatureFlagValue<K> | undefined {
   const raw = getClientCookie(FF_COOKIE_NAME)
   const overrides = parseFeatureFlagCookie(raw)
   if (flag in overrides) return overrides[flag] as FeatureFlagValue<K>
-  return posthog?.getFeatureFlag(flag) as Maybe<FeatureFlagValue<K>>
+  return posthog?.getFeatureFlag(flag) as FeatureFlagValue<K> | undefined
 }
 
 export function useFeatureFlag<K extends FeatureFlagName>(
   flag: K
-): Maybe<FeatureFlagValue<K>> {
-  const [value, setValue] = useState<Maybe<FeatureFlagValue<K>>>(() =>
+): FeatureFlagValue<K> | undefined {
+  const [value, setValue] = useState<FeatureFlagValue<K> | undefined>(() =>
     resolveFlagValue(flag)
   )
 

--- a/apps/site/src/hooks/useFeatureFlag.ts
+++ b/apps/site/src/hooks/useFeatureFlag.ts
@@ -7,15 +7,33 @@ import { getClientCookie } from '@/utils/cookie'
 import posthog from 'posthog-js'
 import { useEffect, useState } from 'react'
 
-function resolveFlagValue(flag: FeatureFlagName): boolean | undefined {
+type VariantFlagResult = string | boolean | undefined
+
+function resolveFlagValue(
+  flag: FeatureFlagName
+): VariantFlagResult {
   const raw = getClientCookie(FF_COOKIE_NAME)
   const overrides = parseFeatureFlagCookie(raw)
   if (flag in overrides) return overrides[flag]
-  return posthog?.isFeatureEnabled(flag)
+  return posthog?.getFeatureFlag(flag)
 }
 
-export function useFeatureFlag(flag: FeatureFlagName): boolean | undefined {
-  const [value, setValue] = useState<boolean | undefined>(() =>
+export function useFeatureFlag(
+  flag: 'actions-v2'
+): boolean | undefined
+export function useFeatureFlag(
+  flag: 'mode-scolaire'
+): boolean | undefined
+export function useFeatureFlag(
+  flag: 'ab-test-tranche'
+): 'control' | 'test' | undefined
+export function useFeatureFlag(
+  flag: FeatureFlagName
+): VariantFlagResult
+export function useFeatureFlag(
+  flag: FeatureFlagName
+): VariantFlagResult {
+  const [value, setValue] = useState<VariantFlagResult>(() =>
     resolveFlagValue(flag)
   )
 

--- a/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
+++ b/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../flags', () => ({
+  FLAGS: {
+    'actions-v2': { kind: 'boolean' },
+    'mode-scolaire': { kind: 'boolean' },
+    variant: { kind: 'variant', variants: ['control', 'test'] },
+  },
+}))
+
 import {
   parseFeatureFlagCookie,
   parseFeatureFlagParams,
@@ -24,17 +33,13 @@ describe('parseFeatureFlagParams', () => {
 
   it('parses a known variant value', () => {
     expect(
-      parseFeatureFlagParams(
-        new URLSearchParams('?ff_ab-test-tranche=test')
-      )
-    ).toEqual({ 'ab-test-tranche': 'test' })
+      parseFeatureFlagParams(new URLSearchParams('?ff_variant=test'))
+    ).toEqual({ variant: 'test' })
   })
 
   it('ignores unknown variant value', () => {
     expect(
-      parseFeatureFlagParams(
-        new URLSearchParams('?ff_ab-test-tranche=wrong')
-      )
+      parseFeatureFlagParams(new URLSearchParams('?ff_variant=wrong'))
     ).toBeNull()
   })
 
@@ -70,8 +75,8 @@ describe('parseFeatureFlagCookie', () => {
 
   it('parses a variant override', () => {
     expect(
-      parseFeatureFlagCookie('{"ab-test-tranche":"test"}')
-    ).toEqual({ 'ab-test-tranche': 'test' })
+      parseFeatureFlagCookie('{"variant":"test"}')
+    ).toEqual({ variant: 'test' })
   })
 
   it('returns empty object for undefined, empty, or malformed input', () => {

--- a/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
+++ b/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
@@ -12,20 +12,36 @@ describe('parseFeatureFlagParams', () => {
 
   it('parses a single truthy flag', () => {
     expect(
-      parseFeatureFlagParams(new URLSearchParams('?ff_my-flag=true'))
-    ).toEqual({ 'my-flag': true })
+      parseFeatureFlagParams(new URLSearchParams('?ff_actions-v2=true'))
+    ).toEqual({ 'actions-v2': true })
   })
 
   it('parses a single falsy flag', () => {
     expect(
-      parseFeatureFlagParams(new URLSearchParams('?ff_my-flag=false'))
-    ).toEqual({ 'my-flag': false })
+      parseFeatureFlagParams(new URLSearchParams('?ff_actions-v2=false'))
+    ).toEqual({ 'actions-v2': false })
   })
 
-  it('keeps non-boolean values as strings', () => {
+  it('parses a known variant value', () => {
     expect(
-      parseFeatureFlagParams(new URLSearchParams('?ff_variant-flag=test'))
-    ).toEqual({ 'variant-flag': 'test' })
+      parseFeatureFlagParams(
+        new URLSearchParams('?ff_ab-test-tranche=test')
+      )
+    ).toEqual({ 'ab-test-tranche': 'test' })
+  })
+
+  it('ignores unknown variant value', () => {
+    expect(
+      parseFeatureFlagParams(
+        new URLSearchParams('?ff_ab-test-tranche=wrong')
+      )
+    ).toBeNull()
+  })
+
+  it('ignores non-boolean values on boolean flags', () => {
+    expect(
+      parseFeatureFlagParams(new URLSearchParams('?ff_actions-v2=test'))
+    ).toBeNull()
   })
 
   it('ignores flags not in FLAGS', () => {

--- a/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
+++ b/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
@@ -28,9 +28,9 @@ describe('parseFeatureFlagParams', () => {
     ).toEqual({ 'variant-flag': 'test' })
   })
 
-  it('ignores empty values', () => {
+  it('ignores flags not in FLAGS', () => {
     expect(
-      parseFeatureFlagParams(new URLSearchParams('?ff_flag='))
+      parseFeatureFlagParams(new URLSearchParams('?ff_unknown=true'))
     ).toBeNull()
   })
 })

--- a/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
+++ b/apps/site/src/services/feature-flags/__tests__/urlParams.test.ts
@@ -22,9 +22,15 @@ describe('parseFeatureFlagParams', () => {
     ).toEqual({ 'my-flag': false })
   })
 
-  it('ignores values other than true/false', () => {
+  it('keeps non-boolean values as strings', () => {
     expect(
-      parseFeatureFlagParams(new URLSearchParams('?ff_flag=yes'))
+      parseFeatureFlagParams(new URLSearchParams('?ff_variant-flag=test'))
+    ).toEqual({ 'variant-flag': 'test' })
+  })
+
+  it('ignores empty values', () => {
+    expect(
+      parseFeatureFlagParams(new URLSearchParams('?ff_flag='))
     ).toBeNull()
   })
 })
@@ -44,6 +50,12 @@ describe('parseFeatureFlagCookie', () => {
     expect(parseFeatureFlagCookie('{"actions-v2":true}')).toEqual({
       'actions-v2': true,
     })
+  })
+
+  it('parses a variant override', () => {
+    expect(
+      parseFeatureFlagCookie('{"ab-test-tranche":"test"}')
+    ).toEqual({ 'ab-test-tranche': 'test' })
   })
 
   it('returns empty object for undefined, empty, or malformed input', () => {

--- a/apps/site/src/services/feature-flags/flags.ts
+++ b/apps/site/src/services/feature-flags/flags.ts
@@ -1,11 +1,10 @@
-type FlagDefinition =
+export type FlagDefinition =
   | { kind: 'boolean' }
   | { kind: 'variant'; variants: readonly string[] }
 
 export const FLAGS = {
   'actions-v2': { kind: 'boolean' },
   'mode-scolaire': { kind: 'boolean' },
-  'ab-test-tranche': { kind: 'variant', variants: ['control', 'test'] },
 } as const satisfies Record<string, FlagDefinition>
 
 export type FeatureFlagName = keyof typeof FLAGS

--- a/apps/site/src/services/feature-flags/flags.ts
+++ b/apps/site/src/services/feature-flags/flags.ts
@@ -1,3 +1,17 @@
-export const FEATURE_FLAGS = ['actions-v2', 'mode-scolaire'] as const
+type FlagDefinition =
+  | { kind: 'boolean' }
+  | { kind: 'variant'; variants: readonly string[] }
 
-export type FeatureFlagName = (typeof FEATURE_FLAGS)[number]
+export const FLAGS = {
+  'actions-v2': { kind: 'boolean' },
+  'mode-scolaire': { kind: 'boolean' },
+  'ab-test-tranche': { kind: 'variant', variants: ['control', 'test'] },
+} as const satisfies Record<string, FlagDefinition>
+
+export type FeatureFlagName = keyof typeof FLAGS
+
+export type FeatureFlagValue<K extends FeatureFlagName> = {
+  'actions-v2': boolean
+  'mode-scolaire': boolean
+  'ab-test-tranche': 'control' | 'test'
+}[K]

--- a/apps/site/src/services/feature-flags/flags.ts
+++ b/apps/site/src/services/feature-flags/flags.ts
@@ -5,6 +5,7 @@ type FlagDefinition =
 export const FLAGS = {
   'actions-v2': { kind: 'boolean' },
   'mode-scolaire': { kind: 'boolean' },
+  'ab-test-tranche': { kind: 'variant', variants: ['control', 'test'] },
 } as const satisfies Record<string, FlagDefinition>
 
 export type FeatureFlagName = keyof typeof FLAGS

--- a/apps/site/src/services/feature-flags/flags.ts
+++ b/apps/site/src/services/feature-flags/flags.ts
@@ -10,8 +10,13 @@ export const FLAGS = {
 
 export type FeatureFlagName = keyof typeof FLAGS
 
-export type FeatureFlagValue<K extends FeatureFlagName> = {
-  'actions-v2': boolean
-  'mode-scolaire': boolean
-  'ab-test-tranche': 'control' | 'test'
-}[K]
+type FlagValueMap = {
+  [K in FeatureFlagName]:
+    (typeof FLAGS)[K] extends { kind: 'variant'; variants: readonly (infer V)[] }
+      ? V
+      : boolean
+}
+
+export type FeatureFlagValue<K extends FeatureFlagName> = FlagValueMap[K]
+
+export type DefaultFlagValues = FlagValueMap

--- a/apps/site/src/services/feature-flags/flags.ts
+++ b/apps/site/src/services/feature-flags/flags.ts
@@ -5,7 +5,6 @@ type FlagDefinition =
 export const FLAGS = {
   'actions-v2': { kind: 'boolean' },
   'mode-scolaire': { kind: 'boolean' },
-  'ab-test-tranche': { kind: 'variant', variants: ['control', 'test'] },
 } as const satisfies Record<string, FlagDefinition>
 
 export type FeatureFlagName = keyof typeof FLAGS

--- a/apps/site/src/services/feature-flags/getFeatureFlag.ts
+++ b/apps/site/src/services/feature-flags/getFeatureFlag.ts
@@ -4,14 +4,32 @@ import { FF_COOKIE_NAME } from './constants'
 import type { FeatureFlagName } from './flags'
 import { parseFeatureFlagCookie } from './urlParams'
 
+type VariantFlagResult = string | boolean | undefined
+
+export async function getFeatureFlag(
+  flag: 'actions-v2',
+  userId: string
+): Promise<boolean | undefined>
+export async function getFeatureFlag(
+  flag: 'mode-scolaire',
+  userId: string
+): Promise<boolean | undefined>
+export async function getFeatureFlag(
+  flag: 'ab-test-tranche',
+  userId: string
+): Promise<'control' | 'test' | undefined>
 export async function getFeatureFlag(
   flag: FeatureFlagName,
   userId: string
-): Promise<string | boolean | undefined> {
+): Promise<VariantFlagResult>
+export async function getFeatureFlag(
+  flag: FeatureFlagName,
+  userId: string
+): Promise<VariantFlagResult> {
   const cookieStore = await cookies()
   const overrides = parseFeatureFlagCookie(
     cookieStore.get(FF_COOKIE_NAME)?.value
   )
-  if (flag in overrides) return overrides[flag]
+  if (flag in overrides) return overrides[flag] as VariantFlagResult
   return posthogClient.getFeatureFlag(flag, userId)
 }

--- a/apps/site/src/services/feature-flags/getFeatureFlag.ts
+++ b/apps/site/src/services/feature-flags/getFeatureFlag.ts
@@ -4,18 +4,16 @@ import { FF_COOKIE_NAME } from './constants'
 import type { FeatureFlagName, FeatureFlagValue } from './flags'
 import { parseFeatureFlagCookie } from './urlParams'
 
-type Maybe<T> = T | undefined
-
 export async function getFeatureFlag<K extends FeatureFlagName>(
   flag: K,
   userId: string
-): Promise<Maybe<FeatureFlagValue<K>>> {
+): Promise<FeatureFlagValue<K> | undefined> {
   const cookieStore = await cookies()
   const overrides = parseFeatureFlagCookie(
     cookieStore.get(FF_COOKIE_NAME)?.value
   )
   if (flag in overrides) return overrides[flag] as FeatureFlagValue<K>
-  return (await posthogClient.getFeatureFlag(flag, userId)) as Maybe<
-    FeatureFlagValue<K>
-  >
+  return (await posthogClient.getFeatureFlag(flag, userId)) as
+    | FeatureFlagValue<K>
+    | undefined
 }

--- a/apps/site/src/services/feature-flags/getFeatureFlag.ts
+++ b/apps/site/src/services/feature-flags/getFeatureFlag.ts
@@ -1,35 +1,21 @@
 import { posthogClient } from '@/services/tracking/posthogServer'
 import { cookies } from 'next/headers'
 import { FF_COOKIE_NAME } from './constants'
-import type { FeatureFlagName } from './flags'
+import type { FeatureFlagName, FeatureFlagValue } from './flags'
 import { parseFeatureFlagCookie } from './urlParams'
 
-type VariantFlagResult = string | boolean | undefined
+type Maybe<T> = T | undefined
 
-export async function getFeatureFlag(
-  flag: 'actions-v2',
+export async function getFeatureFlag<K extends FeatureFlagName>(
+  flag: K,
   userId: string
-): Promise<boolean | undefined>
-export async function getFeatureFlag(
-  flag: 'mode-scolaire',
-  userId: string
-): Promise<boolean | undefined>
-export async function getFeatureFlag(
-  flag: 'ab-test-tranche',
-  userId: string
-): Promise<'control' | 'test' | undefined>
-export async function getFeatureFlag(
-  flag: FeatureFlagName,
-  userId: string
-): Promise<VariantFlagResult>
-export async function getFeatureFlag(
-  flag: FeatureFlagName,
-  userId: string
-): Promise<VariantFlagResult> {
+): Promise<Maybe<FeatureFlagValue<K>>> {
   const cookieStore = await cookies()
   const overrides = parseFeatureFlagCookie(
     cookieStore.get(FF_COOKIE_NAME)?.value
   )
-  if (flag in overrides) return overrides[flag] as VariantFlagResult
-  return posthogClient.getFeatureFlag(flag, userId)
+  if (flag in overrides) return overrides[flag] as FeatureFlagValue<K>
+  return (await posthogClient.getFeatureFlag(flag, userId)) as Maybe<
+    FeatureFlagValue<K>
+  >
 }

--- a/apps/site/src/services/feature-flags/urlParams.ts
+++ b/apps/site/src/services/feature-flags/urlParams.ts
@@ -1,11 +1,13 @@
 import { FF_PARAM_PREFIX } from './constants'
 import { FLAGS } from './flags'
+import type { FlagDefinition } from './flags'
 
 /**
  * Extracts feature flag overrides from URL search parameters.
  *
  * Recognises params with the `FF_PARAM_PREFIX` prefix (e.g. `?ff_actions-v2=true`).
- * Values `true` / `false` are parsed as booleans; any other non-empty value is kept as a string.
+ * Values `true` / `false` are parsed as booleans; variant values are validated against
+ * the flag definition. Unknown flags or invalid values are silently ignored.
  * Returns `null` when no valid overrides are present.
  */
 export function parseFeatureFlagParams(
@@ -16,17 +18,12 @@ export function parseFeatureFlagParams(
     if (!key.startsWith(FF_PARAM_PREFIX)) continue
     const flagName = key.slice(FF_PARAM_PREFIX.length)
     if (!(flagName in FLAGS)) continue
-    const def = FLAGS[flagName as keyof typeof FLAGS]
+    const def = FLAGS[flagName as keyof typeof FLAGS] as FlagDefinition
     if (def.kind === 'boolean') {
       if (value === 'true') overrides[flagName] = true
       else if (value === 'false') overrides[flagName] = false
-    } else {
-      const variants: readonly string[] = (
-        def as unknown as { variants: readonly string[] }
-      ).variants
-      if (variants.includes(value)) {
-        overrides[flagName] = value
-      }
+    } else if (def.variants.includes(value)) {
+      overrides[flagName] = value
     }
   }
   return Object.keys(overrides).length > 0 ? overrides : null

--- a/apps/site/src/services/feature-flags/urlParams.ts
+++ b/apps/site/src/services/feature-flags/urlParams.ts
@@ -1,23 +1,22 @@
 import { FF_PARAM_PREFIX } from './constants'
-import type { FeatureFlagName } from './flags'
 
 /**
  * Extracts feature flag overrides from URL search parameters.
  *
  * Recognises params with the `FF_PARAM_PREFIX` prefix (e.g. `?ff_actions-v2=true`).
+ * Values `true` / `false` are parsed as booleans; any other non-empty value is kept as a string.
  * Returns `null` when no valid overrides are present.
- *
- * @example `?ff_actions-v2=true&ff_new-feature=false` → `{ 'actions-v2': true, 'new-feature': false }`
  */
 export function parseFeatureFlagParams(
   searchParams: URLSearchParams
-): Record<string, boolean> | null {
-  const overrides: Record<string, boolean> = {}
+): Record<string, string | boolean> | null {
+  const overrides: Record<string, string | boolean> = {}
   for (const [key, value] of searchParams.entries()) {
     if (!key.startsWith(FF_PARAM_PREFIX)) continue
     const flagName = key.slice(FF_PARAM_PREFIX.length)
     if (value === 'true') overrides[flagName] = true
     else if (value === 'false') overrides[flagName] = false
+    else if (value.length > 0) overrides[flagName] = value
   }
   return Object.keys(overrides).length > 0 ? overrides : null
 }
@@ -34,12 +33,12 @@ export function stripFeatureFlagParams(url: URL): URL {
 }
 
 /**
- * Parses the raw feature flag cookie value into a typed overrides map.
+ * Parses the raw feature flag cookie value into an overrides map.
  * Returns an empty record for malformed, missing, or non-object input.
  */
 export function parseFeatureFlagCookie(
   raw: string | undefined
-): Partial<Record<FeatureFlagName, boolean>> {
+): Record<string, string | boolean> {
   if (!raw) return {}
   try {
     const parsed = JSON.parse(raw)

--- a/apps/site/src/services/feature-flags/urlParams.ts
+++ b/apps/site/src/services/feature-flags/urlParams.ts
@@ -16,9 +16,18 @@ export function parseFeatureFlagParams(
     if (!key.startsWith(FF_PARAM_PREFIX)) continue
     const flagName = key.slice(FF_PARAM_PREFIX.length)
     if (!(flagName in FLAGS)) continue
-    if (value === 'true') overrides[flagName] = true
-    else if (value === 'false') overrides[flagName] = false
-    else if (value.length > 0) overrides[flagName] = value
+    const def = FLAGS[flagName as keyof typeof FLAGS]
+    if (def.kind === 'boolean') {
+      if (value === 'true') overrides[flagName] = true
+      else if (value === 'false') overrides[flagName] = false
+    } else {
+      const variants: readonly string[] = (
+        def as unknown as { variants: readonly string[] }
+      ).variants
+      if (variants.includes(value)) {
+        overrides[flagName] = value
+      }
+    }
   }
   return Object.keys(overrides).length > 0 ? overrides : null
 }

--- a/apps/site/src/services/feature-flags/urlParams.ts
+++ b/apps/site/src/services/feature-flags/urlParams.ts
@@ -1,4 +1,5 @@
 import { FF_PARAM_PREFIX } from './constants'
+import { FLAGS } from './flags'
 
 /**
  * Extracts feature flag overrides from URL search parameters.
@@ -14,6 +15,7 @@ export function parseFeatureFlagParams(
   for (const [key, value] of searchParams.entries()) {
     if (!key.startsWith(FF_PARAM_PREFIX)) continue
     const flagName = key.slice(FF_PARAM_PREFIX.length)
+    if (!(flagName in FLAGS)) continue
     if (value === 'true') overrides[flagName] = true
     else if (value === 'false') overrides[flagName] = false
     else if (value.length > 0) overrides[flagName] = value


### PR DESCRIPTION
## What

The feature flag system now supports PostHog A/B test (multivariate) flags alongside boolean flags, with strong typing on the return value.

### Unified registry (`flags.ts`)

```ts
export const FLAGS = {
  "actions-v2": { kind: "boolean" },
  "mode-scolaire": { kind: "boolean" },
  "ab-test-tranche": { kind: "variant", variants: ["control", "test"] },
} as const satisfies Record<string, FlagDefinition>
```

One source of truth. `satisfies` validates the structure at build time.

### Strict return types via function overloads

```ts
// Boolean flag → `boolean | undefined`
const enabled = useFeatureFlag("mode-scolaire")

// Variant flag → `"control" | "test" | undefined`
const variant = useFeatureFlag("ab-test-tranche")
```

No generics, no conditional types — function overloads keep ESLint happy and provide exact autocomplete.

### URL params accept string values

Any non-empty string is accepted (not just `true`/`false`):

```
?ff_actions-v2=true
?ff_ab-test=test
?ff_ab-test=control
```
