### PR TITLE
feat: add React Native WebView postMessage support to data share flow

### DIFF
--- a/apps/site/src/components/iframe/IframeDataShareModal.test.tsx
+++ b/apps/site/src/components/iframe/IframeDataShareModal.test.tsx
@@ -152,6 +152,25 @@ describe('IframeDataShareModal', () => {
         ).not.toBeInTheDocument()
         expect(document.body.style.overflow).toBe('auto')
       })
+
+      it('sends the error message to React Native WebView when rejecting and ReactNativeWebView is present', () => {
+        const mockRnPostMessage = vi.fn()
+        window.parent.postMessage = vi.fn()
+        ;(window as any).ReactNativeWebView = { postMessage: mockRnPostMessage }
+
+        fireEvent.click(screen.getByTestId('iframe-datashare-refuser'))
+
+        expect(mockRnPostMessage).toHaveBeenCalledTimes(1)
+        expect(mockRnPostMessage).toHaveBeenCalledWith(
+          JSON.stringify({
+            messageType: 'ngc-iframe-share',
+            error: 'The user refused to share his result.',
+          })
+        )
+
+        // Clean up the global we added
+        delete (window as any).ReactNativeWebView
+      })
     })
   })
 

--- a/apps/site/src/components/iframe/IframeDataShareModal.tsx
+++ b/apps/site/src/components/iframe/IframeDataShareModal.tsx
@@ -2,6 +2,7 @@
 
 import Button from '@/design-system/buttons/Button'
 import Card from '@/design-system/layout/Card'
+import { postMessageToReactNative } from '@/helpers/iframe/postMessageToReactNative'
 import { shareDataWithIntegrator } from '@/helpers/iframe/shareDataWithIntegrator'
 import { useClientTranslation } from '@/hooks/useClientTranslation'
 import { useIframe } from '@/hooks/useIframe'
@@ -49,6 +50,9 @@ export default function IframeDataShareModal({ computedResults }: Props) {
     if (window.top && window.top !== window) {
       window.top.postMessage(message, '*')
     }
+
+    postMessageToReactNative(message)
+
     setIsOpen(false)
     resetOverflow()
   }

--- a/apps/site/src/helpers/iframe/postMessageToReactNative.ts
+++ b/apps/site/src/helpers/iframe/postMessageToReactNative.ts
@@ -1,0 +1,25 @@
+/**
+ * Send a message to a React Native WebView via the standard bridge API.
+ *
+ * React Native WebView injects `window.ReactNativeWebView.postMessage` into
+ * the web page. It expects a **string**, so we JSON-stringify the payload.
+ *
+ * Guards:
+ * - SSR safety: checks `typeof window !== 'undefined'`
+ * - API existence: checks `ReactNativeWebView?.postMessage` is a function
+ *
+ * @see https://stackoverflow.com/questions/68334181
+ */
+export function postMessageToReactNative(message: unknown) {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const rnWebView = (window as any).ReactNativeWebView as
+    | { postMessage: (msg: string) => void }
+    | undefined
+
+  if (rnWebView?.postMessage) {
+    rnWebView.postMessage(JSON.stringify(message))
+  }
+}

--- a/apps/site/src/helpers/iframe/shareDataWithIntegrator.ts
+++ b/apps/site/src/helpers/iframe/shareDataWithIntegrator.ts
@@ -1,5 +1,6 @@
 import { carboneMetric, eauMetric } from '@/constants/model/metric'
 import type { ComputedResults } from '@/publicodes-state/types'
+import { postMessageToReactNative } from './postMessageToReactNative'
 
 export function shareDataWithIntegrator(computedResults: ComputedResults) {
   const sharedData = {
@@ -14,8 +15,12 @@ export function shareDataWithIntegrator(computedResults: ComputedResults) {
     },
   }
 
-  window.parent.postMessage(
-    { messageType: 'ngc-iframe-share', data: sharedData },
-    '*'
-  )
+  const message = {
+    messageType: 'ngc-iframe-share',
+    data: sharedData,
+  }
+
+  window.parent.postMessage(message, '*')
+
+  postMessageToReactNative(message)
 }


### PR DESCRIPTION
Send the same ngc-iframe-share message to window.ReactNativeWebView.postMessage() alongside the classic window.parent.postMessage(), for both accept and reject flows.
