### PR TITLE
✨ Add createPage helper and ESLint rule to enforce feature flags in e2e

### DIFF
--- a/.eslint-configs/e2e.js
+++ b/.eslint-configs/e2e.js
@@ -1,0 +1,39 @@
+import playwright from 'eslint-plugin-playwright'
+
+export default {
+  files: ['apps/site/e2e/**/*.ts'],
+  ignores: ['apps/site/e2e/fixtures/feature-flags.ts'],
+  extends: [playwright.configs['flat/recommended']],
+  plugins: {
+    'ngc-e2e': {
+      rules: {
+        'no-browser-newpage': {
+          meta: {
+            type: 'problem',
+            docs: {
+              description:
+                'Use createPage(browser) instead of browser.newPage() to ensure feature flags are applied.',
+            },
+            messages: {
+              useCreatePage:
+                'Use createPage(browser) instead of browser.newPage() to ensure feature flags are applied.',
+            },
+            schema: [],
+          },
+          create(context) {
+            return {
+              'CallExpression[callee.object.name="browser"][callee.property.name="newPage"]'(
+                node
+              ) {
+                context.report({ node, messageId: 'useCreatePage' })
+              },
+            }
+          },
+        },
+      },
+    },
+  },
+  rules: {
+    'ngc-e2e/no-browser-newpage': 'error',
+  },
+}

--- a/apps/site/e2e/features/groups.spec.ts
+++ b/apps/site/e2e/features/groups.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '../fixtures'
-import { DEFAULT_FLAGS, FeatureFlags } from '../fixtures/feature-flags'
+import { createPage } from '../fixtures/feature-flags'
 import { Group } from '../fixtures/groups'
 import { NGCTest } from '../fixtures/ngc-test'
 import { TutorialPage } from '../fixtures/tutorial'
@@ -141,8 +141,7 @@ test.describe('A user with a completed test that joined a group', () => {
   let page: Page
 
   test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage()
-    new FeatureFlags(page).set(DEFAULT_FLAGS)
+    page = await createPage(browser)
     await new NGCTest(page).skipAll()
     await expect(page).toHaveURL('/fin')
 

--- a/apps/site/e2e/features/mode-scolaire.spec.ts
+++ b/apps/site/e2e/features/mode-scolaire.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '../fixtures'
-import { DEFAULT_FLAGS, FeatureFlags } from '../fixtures/feature-flags'
+import { createPage } from '../fixtures/feature-flags'
 import { NGCTest } from '../fixtures/ngc-test'
 import { Organisation } from '../fixtures/organisations'
 import { Poll } from '../fixtures/polls'
@@ -25,11 +25,7 @@ test.describe('When a user completes the test via the scolaire poll invite link'
   test.beforeAll(async ({ browser }) => {
     test.setTimeout(60_000)
 
-    page = await browser.newPage()
-
-    // Set feature flags on this page since auto-fixtures don't run in beforeAll
-    const ff = new FeatureFlags(page)
-    await ff.set({ ...DEFAULT_FLAGS })
+    page = await createPage(browser)
 
     const adminContext = await browser.newContext({
       storageState: ORGANISATION_ADMIN_STATE,

--- a/apps/site/e2e/features/polls.spec.ts
+++ b/apps/site/e2e/features/polls.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '../fixtures'
+import { createPage } from '../fixtures/feature-flags'
 import { NGCTest } from '../fixtures/ngc-test'
 import { Organisation } from '../fixtures/organisations'
 import { Poll } from '../fixtures/polls'
@@ -121,7 +122,8 @@ test.describe('A user with a completed test that joined a poll', () => {
   let page: Page
 
   test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage()
+    page = await createPage(browser)
+
     const adminContext = await browser.newContext({
       storageState: ORGANISATION_ADMIN_STATE,
     })

--- a/apps/site/e2e/fixtures/feature-flags.ts
+++ b/apps/site/e2e/fixtures/feature-flags.ts
@@ -1,4 +1,4 @@
-import { test as base, type Page } from '@playwright/test'
+import { test as base, type Browser, type Page } from '@playwright/test'
 
 import { FF_COOKIE_NAME } from '@/services/feature-flags/constants'
 import type { DefaultFlagValues } from '@/services/feature-flags/flags'
@@ -44,6 +44,13 @@ export class FeatureFlags {
       return {}
     }
   }
+}
+
+export async function createPage(browser: Browser): Promise<Page> {
+  const page = await browser.newPage()
+  const ff = new FeatureFlags(page)
+  await ff.set({ ...DEFAULT_FLAGS })
+  return page
 }
 
 interface FeatureFlagFixtures {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,9 +5,10 @@ import nextVanilla from 'eslint-config-next'
 import eslintConfigPrettier from 'eslint-config-prettier/flat'
 import eslintPluginImport from 'eslint-plugin-import'
 import jsxA11y from 'eslint-plugin-jsx-a11y'
-import playwright from 'eslint-plugin-playwright'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import typescriptEslint from 'typescript-eslint'
+
+import e2eConfig from './.eslint-configs/e2e.js'
 
 // Avoid duplicate import plugin setup which fails
 const { import: _import, ...nextPlugins } = nextVanilla[0].plugins
@@ -15,6 +16,7 @@ const { import: _import, ...nextPlugins } = nextVanilla[0].plugins
 export default defineConfig([
   globalIgnores([
     'eslint.config.js',
+    '.eslint-configs/',
     '**/prisma.config.js',
     '**/coverage/**',
     '**/dist/**',
@@ -186,10 +188,7 @@ export default defineConfig([
       ],
     },
   },
-  {
-    files: ['apps/site/e2e/**/*.ts'],
-    extends: [playwright.configs['flat/recommended']],
-  },
+  e2eConfig,
   // Must be last to ensure compatibility with Prettier
   eslintConfigPrettier,
 ])


### PR DESCRIPTION
Add a createPage(browser) helper that wraps browser.newPage() with automatic feature flags injection, preventing the fragile pattern of manually setting flags in beforeAll blocks.

- Add exported createPage(browser) to feature-flags.ts
- Replace all manual browser.newPage() + FeatureFlags.set() with createPage()
- Fix missing await on FeatureFlags.set() in groups.spec.ts
- Extract e2e ESLint config into .eslint-configs/e2e.js
- Add custom ESLint rule no-browser-newpage to block raw browser.newPage()