### PR TITLE
:bug: check Safari <= 16 instead of <= 18 for storage access prompt

### DIFF
--- a/apps/site/src/app/[locale]/_components/mainLayoutProviders/IframeOptionsContext.tsx
+++ b/apps/site/src/app/[locale]/_components/mainLayoutProviders/IframeOptionsContext.tsx
@@ -38,7 +38,8 @@ export const IframeOptionsProvider = ({
   // Detect iframe mode using window check
   const isIframe = getIsIframe()
 
-  // Special case : Safari doesn't handle cookies in iframes
+  // Special case : Safari ≤ 16 doesn't handle cookies in iframes.
+  // Safari 17+ supports partitioned cookies (CHIPS) so this is a no-op.
   const { needPermission, askForPermission } = useStoragePermissions()
 
   const [isIframeShareData, setIsIframeShareData] = useState(() => {

--- a/apps/site/src/app/[locale]/_components/mainLayoutProviders/_hooks/useStoragePermissions.ts
+++ b/apps/site/src/app/[locale]/_components/mainLayoutProviders/_hooks/useStoragePermissions.ts
@@ -1,19 +1,17 @@
 'use client'
 
 import {
-  isStorageAccessApiSupported,
   requestStorageAccess,
   requiresStoragePermissions,
 } from '@/helpers/iframe/storageAccess'
+import { captureException } from '@sentry/nextjs'
 import { useCallback, useEffect, useState } from 'react'
 
 export const useStoragePermissions = (): {
   needPermission: boolean
   askForPermission: () => Promise<void> | undefined
 } => {
-  const [needPermission, setNeedPermission] = useState(() =>
-    isStorageAccessApiSupported()
-  )
+  const [needPermission, setNeedPermission] = useState(false)
 
   // On mount, check if storage access is already granted (e.g. after a
   // Safari auto-reload following a successful requestStorageAccess grant).
@@ -21,7 +19,7 @@ export const useStoragePermissions = (): {
     requiresStoragePermissions()
       .then(setNeedPermission)
       .catch(() => {
-        // Keep the conservative default (true)
+        // Keep the conservative default (false)
       })
   }, [])
 
@@ -30,8 +28,9 @@ export const useStoragePermissions = (): {
       await requestStorageAccess()
       const needsPermission = await requiresStoragePermissions()
       setNeedPermission(needsPermission)
-    } catch {
-      // Do nothing
+    } catch (error) {
+      captureException(error)
+      setNeedPermission(false)
     }
   }, [])
 

--- a/apps/site/src/helpers/iframe/storageAccess.ts
+++ b/apps/site/src/helpers/iframe/storageAccess.ts
@@ -5,13 +5,21 @@ export function isSafari(): boolean {
   return userAgent.includes('safari') && !userAgent.includes('chrome')
 }
 
-export function isSafariVersionBeforeOrEgalTo18(): boolean {
-  if (typeof navigator === 'undefined') return false
+export function isSafariMajorVersion(): number | null {
+  if (typeof navigator === 'undefined') return null
   const match = /Version\/(\d+)\.(\d+)/i.exec(navigator.userAgent)
-  if (!match) return false
-  const major = parseInt(match[1], 10)
+  if (!match) return null
+  return parseInt(match[1], 10)
+}
 
-  return isSafari() && major <= 18
+/**
+ * Safari ≤ 16 blocks third-party cookies and requires requestStorageAccess().
+ * Safari 17+ supports partitioned cookies (CHIPS) so the overlay is unnecessary.
+ */
+function requiresStorageAccessPrompt(): boolean {
+  if (!isSafari()) return false
+  const major = isSafariMajorVersion()
+  return major !== null && major <= 16
 }
 
 export function isStorageAccessApiSupported(): boolean {
@@ -30,13 +38,19 @@ export async function hasStorageAccess(): Promise<boolean> {
 
 export async function requestStorageAccess(): Promise<void> {
   if (typeof document === 'undefined') return
+
   await document.requestStorageAccess()
 }
 
-// Only Safari <= v18 needs this
+/**
+ * Returns true when the browser needs the Storage Access API prompt.
+ *
+ * Only Safari ≤ 16 requires this — Safari 17+ supports partitioned cookies
+ * (CHIPS) and the app sets cookies with `partitioned: true`.
+ */
 export async function requiresStoragePermissions(): Promise<boolean> {
   return (
-    isSafariVersionBeforeOrEgalTo18() &&
+    requiresStorageAccessPrompt() &&
     isStorageAccessApiSupported() &&
     !(await hasStorageAccess())
   )


### PR DESCRIPTION
Safari 17+ supports partitioned cookies (CHIPS), so only Safari <= 16 needs the Storage Access API overlay.

Also adjusts useStoragePermissions to default to false and report errors via captureException instead of swallowing them.