### PR TITLE
fix: allow nightly model to be loaded

### DIFF
--- a/apps/server/src/features/simulations/simulations.validator.ts
+++ b/apps/server/src/features/simulations/simulations.validator.ts
@@ -10,7 +10,8 @@ import { LoginDto } from '../authentication/authentication.validator.ts'
 import { PublicPollParams } from '../organisations/organisations.validator.ts'
 import { UserParams } from '../users/users.validator.ts'
 
-const MODEL_REGEX = /^[A-Z]+-[a-z]+-(pr-\d+|\d+\.\d+\.\d+(-[\w.]+)?)$/
+const MODEL_REGEX =
+  /^[A-Z]+-[a-z]+-(?:pr-(?:nightly|\d+)|\d+\.\d+\.\d+(?:-[\w.]+)?)$/
 
 const SimulationParams = v.strictObject({
   simulationId: v.pipe(v.string(), v.uuid()),

--- a/apps/site/src/app/[locale]/simulateur/_service/getNewSimulationModelService.ts
+++ b/apps/site/src/app/[locale]/simulateur/_service/getNewSimulationModelService.ts
@@ -19,7 +19,7 @@ export async function getNewSimulationModelService({
   locale: Locale
   mode?: SimulationMode
 }): Promise<Model> {
-  const { region: regionParam, PRNumberParam } = await searchParams
+  const { region: regionParam, PR: PRNumberParam } = await searchParams
 
   let userRegion: UserRegion | undefined
   let PRNumber: string | undefined

--- a/apps/site/src/helpers/server/error.ts
+++ b/apps/site/src/helpers/server/error.ts
@@ -52,7 +52,7 @@ export class UnknownError extends Error {
 
 export class InvalidInputError extends Error {
   constructor(public errorObject: unknown) {
-    super(`Invalid Input Error: ${JSON.stringify(errorObject)}`)
+    super('Invalid Input')
     this.name = 'InvalidInputError'
   }
 }

--- a/apps/site/src/helpers/server/error.ts
+++ b/apps/site/src/helpers/server/error.ts
@@ -52,7 +52,7 @@ export class UnknownError extends Error {
 
 export class InvalidInputError extends Error {
   constructor(public errorObject: unknown) {
-    super('Invalid Input')
+    super(`Invalid Input Error: ${JSON.stringify(errorObject)}`)
     this.name = 'InvalidInputError'
   }
 }

--- a/packages/core/prisma/migrations/20260617160000_alter_model_domain_accept_nightly/migration.sql
+++ b/packages/core/prisma/migrations/20260617160000_alter_model_domain_accept_nightly/migration.sql
@@ -1,0 +1,2 @@
+ALTER DOMAIN "ngc"."MODEL" DROP CONSTRAINT "MODEL_check";
+ALTER DOMAIN "ngc"."MODEL" ADD CONSTRAINT "MODEL_check" CHECK ( VALUE ~ '^[A-Z]+-[a-z]+-pr-(nightly|\d+)$' OR VALUE ~ '^[A-Z]+-[a-z]+-\d+\.\d+\.\d+(-[\w.]+)?$' );


### PR DESCRIPTION
Correction de la regex de validation du modèle qui n'acceptait pas XX-xx-pr-nightly.

@johangirod (et @Aebrathia @bjlaa) j'ai pas mal galéré avec la gestion des erreurs. Notamment la première 400 que j'avais, qui n'affichait pas le message (je le log mais c'est moche dans la console 😅). Et ensuite j'avais une 500 du serveur pour la même raison, du coup j'ai galéré, Claude m'a bien aidé.. Vous gérez comment de votre côté ?

<img width="1414" height="729" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/5bc047af-7004-4739-896a-26778ef7e330" />
