### PR TITLE
✅ add user account E2E tests

### DIFF
--- a/apps/site/e2e/features/groups.spec.ts
+++ b/apps/site/e2e/features/groups.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import type { Page } from '@playwright/test'
 import { expect, test } from '../fixtures'
 import { createPage } from '../fixtures/feature-flags'
@@ -76,6 +77,18 @@ test.describe('The group result page, when accessed by an admin', () => {
   test('displays main section', async ({ page }) => {
     await expect(page.getByTestId('votre-empreinte-title')).toBeVisible()
   })
+
+  test('displays the admin first name in the ranking', async ({
+    page,
+    group,
+  }) => {
+    await expect(
+      page
+        .getByTestId('participant-name')
+        .filter({ hasText: group.admin.firstName })
+    ).toBeVisible()
+    await expect(page.getByTestId('current-member-badge')).toBeVisible()
+  })
 })
 
 test.describe('A new user', () => {
@@ -130,6 +143,39 @@ test.describe('A new user', () => {
     await expect(page).toHaveURL('/fin')
     await page.getByTestId('see-group-result-button').click()
     await expect(page).toHaveURL(group.url)
+  })
+
+  // TODO: Fails because updateGroupParticipant does not persist the participant name
+  // on the server side for non-admin users. The ranking displays empty names.
+  test.skip('sees its first name in the group ranking after joining', async ({
+    page,
+    ngcTest,
+    tutorialPage,
+    group,
+  }) => {
+    test.setTimeout(60_000)
+    const participantName = faker.person.firstName()
+    const user = new User(page, {
+      firstName: participantName,
+      lastName: faker.person.lastName(),
+      email: faker.internet.email({
+        provider: `${process.env.MAILISK_NAMESPACE!}.mailisk.net`,
+        firstName: participantName,
+      }),
+    })
+
+    await group.joinWithInviteLink(user)
+    await tutorialPage.skip()
+    await ngcTest.skipAllQuestions()
+    await user.fillEmailAndCompleteVerification()
+    await expect(page).toHaveURL('/fin')
+
+    await page.getByTestId('see-group-result-button').click()
+    await expect(page).toHaveURL(group.url)
+
+    await expect(
+      page.getByTestId('participant-name').filter({ hasText: participantName })
+    ).toBeVisible()
   })
 })
 

--- a/apps/site/e2e/features/user-account.spec.ts
+++ b/apps/site/e2e/features/user-account.spec.ts
@@ -1,0 +1,77 @@
+import { faker } from '@faker-js/faker'
+import { expect, test } from '../fixtures'
+import { UserMailbox } from '../helpers/user-mailbox'
+import { GROUP_ADMIN_STATE, USER_ACCOUNT_STATE } from '../state'
+
+test.use({ storageState: USER_ACCOUNT_STATE })
+
+test.describe('Logout', () => {
+  test('should log out and redirect to homepage', async ({ page }) => {
+    await page.goto('/mon-espace')
+    await expect(page.getByTestId('my-results-tab')).toBeVisible()
+
+    await page.getByTestId('my-space-button').click()
+
+    await page.getByTestId('my-space-logout-button').click()
+
+    await expect(page).toHaveURL('/')
+
+    await page.goto('/mon-espace')
+    await expect(page).not.toHaveURL('/mon-espace')
+  })
+})
+
+test.describe('Email change', () => {
+  test.setTimeout(60_000)
+
+  test('can change email from personal space', async ({ page }) => {
+    const newEmail = faker.internet.email({
+      provider: `${process.env.MAILISK_NAMESPACE!}.mailisk.net`,
+      firstName: faker.person.firstName(),
+      lastName: faker.person.lastName(),
+    })
+
+    await page.goto('/mon-espace/parametres')
+    await expect(page.getByTestId('user-email-display')).toBeVisible()
+
+    await page.getByTestId('edit-email-button').click()
+
+    await page.locator('input[name="email"]').first().fill(newEmail)
+    await page.getByTestId('submit-button').click()
+
+    const codeInput = page.getByTestId('verification-code-input')
+    await expect(codeInput).toBeInViewport({ timeout: 10_000 })
+
+    const code = await new UserMailbox(newEmail).getVerificationCode()
+    await codeInput.fill(code)
+
+    await expect(page.getByTestId('success-message')).toBeVisible({
+      timeout: 10_000,
+    })
+
+    await page.reload()
+    await expect(page.getByTestId('user-email-display')).toHaveText(
+      newEmail.toLowerCase()
+    )
+  })
+})
+
+test.describe('Simulation deletion', () => {
+  test.use({ storageState: GROUP_ADMIN_STATE })
+
+  test('can delete a simulation from personal space', async ({ page }) => {
+    await page.goto('/mon-espace')
+    await expect(page.getByTestId('results-list-title')).toBeVisible()
+
+    const deleteButtons = page.getByTestId('delete-simulation-button')
+    const initialCount = await deleteButtons.count()
+    expect(initialCount).toBeGreaterThan(0)
+
+    await deleteButtons.first().click()
+    await page.getByTestId('confirm-delete-simulation-button').click()
+
+    await expect(deleteButtons).toHaveCount(initialCount - 1, {
+      timeout: 10_000,
+    })
+  })
+})

--- a/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/_components/ProfileTabs.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/_components/ProfileTabs.tsx
@@ -29,7 +29,9 @@ export default async function ProfileTab({
     {
       id: 'dashboard',
       label: (
-        <span className="flex flex-col items-center gap-1 md:flex-row">
+        <span
+          className="flex flex-col items-center gap-1 md:flex-row"
+          data-testid="my-results-tab">
           <BilanIcon
             className={twMerge(
               'h-6 w-6',

--- a/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/_components/resultsView/ResultsList.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/_components/resultsView/ResultsList.tsx
@@ -21,7 +21,9 @@ export default function ResultsList({
 }: Props) {
   return (
     <div className="mb-8 md:mb-10">
-      <h2 className="mb-6 text-2xl md:mb-8">
+      <h2
+        className="mb-6 text-2xl md:mb-8"
+        data-testid="results-list-title">
         <Trans locale={locale} i18nKey="mon-espace.resultsList.title">
           Tous mes résultats
         </Trans>

--- a/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/parametres/_components/UserEmail.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/parametres/_components/UserEmail.tsx
@@ -42,11 +42,14 @@ export default function UserEmail({ user }: Props) {
 
   return (
     <div className="flex flex-wrap items-center">
-      <p className="m-0 text-sm md:text-base">{user.email}</p>
+      <p className="m-0 text-sm md:text-base" data-testid="user-email-display">
+        {user.email}
+      </p>
 
       <Button
         color="link"
         className="text-base font-bold md:text-lg"
+        data-testid="edit-email-button"
         onClick={onEditClick}>
         <Trans i18nKey="mon-espace.settings.userInfos.editLabel">
           Modifier

--- a/apps/site/src/app/[locale]/(server)/(large)/amis/resultats/_components/groupResults/ranking/RankingMember.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/amis/resultats/_components/groupResults/ranking/RankingMember.tsx
@@ -123,10 +123,14 @@ export default function RankingMember({
               : getRank(index)}
           </span>
 
-          <span className={textColor}>{participant.name}</span>
+          <span className={textColor} data-testid="participant-name">
+            {participant.name}
+          </span>
 
           {isCurrentMember && (
-            <Badge className="text-secondary-800 ml-2 inline rounded-xl border-pink-100 bg-pink-200 text-xs font-bold">
+            <Badge
+              className="text-secondary-800 ml-2 inline rounded-xl border-pink-100 bg-pink-200 text-xs font-bold"
+              data-testid="current-member-badge">
               <Trans>Vous</Trans>
             </Badge>
           )}

--- a/apps/site/src/components/interactions/DeleteButtonWithConfirmModal.tsx
+++ b/apps/site/src/components/interactions/DeleteButtonWithConfirmModal.tsx
@@ -38,6 +38,7 @@ export function DeleteButtonWithConfirmModal({
       <Button
         onClick={() => setIsModalOpen(true)}
         color="link"
+        data-testid="delete-simulation-button"
         className="font-normal text-red-700 hover:text-red-800">
         <Trans i18nKey="mySpace.resultList.item.delete.mainButton.label">
           Supprimer
@@ -53,7 +54,8 @@ export function DeleteButtonWithConfirmModal({
             disabled={isPending}
             onClick={handleDeleteAction}
             key="submit"
-            color="red">
+            color="red"
+            data-testid="confirm-delete-simulation-button">
             {isPending && <Loader color="light" className="mr-2" />}
             <Trans i18nKey="mySpace.resultList.item.delete.modal.confirm">
               Confirmer la suppression

--- a/apps/site/src/components/layout/headerServer/MySpaceDropdown.tsx
+++ b/apps/site/src/components/layout/headerServer/MySpaceDropdown.tsx
@@ -239,6 +239,7 @@ export default function MySpaceDropdown({ email, onLogout }: Props) {
         size="sm"
         color="secondary"
         className="inline-flex gap-1 align-baseline"
+        data-testid="my-space-button"
         aria-expanded={isOpen}
         aria-haspopup="true"
         aria-controls={menuId}
@@ -267,10 +268,11 @@ export default function MySpaceDropdown({ email, onLogout }: Props) {
           tabIndex={-1}>
           <ul>
             <li>
-              <Link
+                <Link
                 ref={firstMenuItemRef}
                 href={MON_ESPACE_PATH}
                 role="menuitem"
+                data-testid="my-space-link"
                 className={twMerge(
                   'text-default hover:bg-primary-100 block min-h-10 px-4 py-2 text-sm no-underline! transition-colors focus:outline-none',
                   isKeyboardNavigation
@@ -303,10 +305,11 @@ export default function MySpaceDropdown({ email, onLogout }: Props) {
               </Link>
             </li>
             <li>
-              <button
+                <button
                 ref={logoutButtonRef}
                 type="button"
                 role="menuitem"
+                data-testid="my-space-logout-button"
                 className="text-default hover:bg-primary-50 focus:bg-primary-50 focus:ring-primary-700 flex min-h-10 w-full items-center gap-2 px-4 py-2 text-sm transition-colors hover:underline! focus:underline! focus:ring-2 focus:ring-offset-2 focus:outline-none"
                 onClick={handleLogout}
                 onKeyDown={(e) => {

--- a/apps/site/src/design-system/layout/Badge.tsx
+++ b/apps/site/src/design-system/layout/Badge.tsx
@@ -33,6 +33,7 @@ export default function Badge({
   category,
   tag = 'div',
   border = true,
+  ...props
 }: PropsWithChildren<{
   color?: BadgeColor
   size?: 'xs' | 'sm' | 'md'
@@ -40,10 +41,15 @@ export default function Badge({
   category?: string
   tag?: 'div' | 'span' | 'p' | 'h2' | 'h3' | 'h4'
   border?: boolean
+  ['data-testid']?: string
 }>) {
+  const {
+    'data-testid': dataTestId,
+  } = props
   const Tag = tag
   return (
     <Tag
+      data-testid={dataTestId}
       className={twMerge(
         'inline-block rounded-sm border-2 px-2 leading-none font-black whitespace-nowrap',
         sizeClassNames[size],


### PR DESCRIPTION
## What

E2E tests for 4 user account features.

### Tests added
- **Logout** - verifies redirect to / and /mon-espace access denied
- **Email change** - via /mon-espace/parametres, with Mailisk verification
- **Simulation deletion** - from /mon-espace, counting before/after
- **Admin first name in ranking** - in groups.spec.ts, checks participant-name + current-member-badge
- **Participant first name** - .skip() due to server bug: updateGroupParticipant does not persist name for non-admin

### Components modified
Added data-testid in 7 components: MySpaceDropdown, UserEmail, RankingMember, ResultsList, DeleteButtonWithConfirmModal, ProfileTabs, Badge
