### PR TITLE
🐛 Fix hook count mismatch in EngineProvider (NOSGESTESCLIMAT-NEXTJS-BB1)

### DIFF
--- a/apps/site/src/publicodes-state/providers/engineProvider/hooks/useEngine.ts
+++ b/apps/site/src/publicodes-state/providers/engineProvider/hooks/useEngine.ts
@@ -4,6 +4,7 @@ import { carboneMetric } from '@/constants/model/metric'
 import { safeEvaluateHelper } from '@/publicodes-state/helpers/safeEvaluateHelper'
 import { safeGetRuleHelper } from '@/publicodes-state/helpers/safeGetRuleHelper'
 import type { Metric, SafeEvaluate, Situation } from '@/publicodes-state/types'
+import { isServerSide } from '@/utils/nextjs/isServerSide'
 import type {
   DottedName,
   NGCRuleNode,
@@ -26,6 +27,9 @@ export function useEngine(
   initialSituation: Situation
 ) {
   const engine = useMemo(() => {
+    if (isServerSide()) {
+      return undefined
+    }
     const nbRules = Object.keys(rules).length
     console.time(`⚙️ Parsing ${nbRules}`)
     const engine = new Engine<DottedName>(rules, {
@@ -69,12 +73,15 @@ export function useEngine(
   }, [rules])
 
   const pristineEngine = useMemo(
-    () => engine.shallowCopy().setSituation({}),
+    () => (engine ? engine.shallowCopy().setSituation({}) : undefined),
     [engine]
   )
 
   const safeEvaluate = useCallback(
     (expr: PublicodesExpression, metric: Metric = carboneMetric) => {
+      if (!engine) {
+        return null
+      }
       // Somehow, for the case for `textile . empreinte`, the evaluation was not working. Defining the context only for "non default" metric ("eau"). Still, it seems that there is a bug... Maybe due to some delay somewhere.
       const exprWithContext =
         metric === carboneMetric
@@ -95,7 +102,7 @@ export function useEngine(
     (ruleName: DottedName) => NGCRuleNode | undefined
   >(
     () => (ruleName: DottedName) =>
-      safeGetRuleHelper(ruleName, engine) ?? undefined,
+      engine ? (safeGetRuleHelper(ruleName, engine) ?? undefined) : undefined,
     [engine]
   )
 

--- a/apps/site/src/publicodes-state/providers/engineProvider/hooks/useEngineSituation.ts
+++ b/apps/site/src/publicodes-state/providers/engineProvider/hooks/useEngineSituation.ts
@@ -10,7 +10,7 @@ import type { DottedName } from '@incubateur-ademe/nosgestesclimat'
 import { useCallback } from 'react'
 
 interface Props {
-  engine: Engine
+  engine: Engine | undefined
   safeEvaluate: SafeEvaluate
   rawMissingVariables: MissingVariables
 }
@@ -25,6 +25,9 @@ export function useAddToEngineSituation({
   const { situation } = useCurrentSimulation()
   const addToEngineSituation = useCallback(
     (situationToAdd: Situation): Situation => {
+      if (!engine) {
+        return {} as Situation
+      }
       engine.setSituation({ ...situation, ...situationToAdd })
 
       // The current engine situation might have been filtered with Publicodes filtering logic.

--- a/apps/site/src/publicodes-state/providers/engineProvider/provider.tsx
+++ b/apps/site/src/publicodes-state/providers/engineProvider/provider.tsx
@@ -1,17 +1,9 @@
-/*
-  We disable the rule of hooks here because we need to ensure
-  that the provider is only rendered on the client before callings engine initialisation hook.
-  Indeed the cost of initializing the engine is too high to be done on the server.
-*/
-/* eslint-disable react-hooks/rules-of-hooks */
-
 'use client'
 
 import { useState, type PropsWithChildren } from 'react'
 
 import useCurrentSimulation from '@/publicodes-state/hooks/useCurrentSimulation/useCurrentSimulation'
 import type { Situation } from '@/publicodes-state/types'
-import { isServerSide } from '@/utils/nextjs/isServerSide'
 import type { DottedName, NGCRules } from '@incubateur-ademe/nosgestesclimat'
 import { EngineContext } from './context'
 import { useCategories } from './hooks/useCategories'
@@ -31,9 +23,6 @@ export default function EngineProvider({
   children,
   initialSituation,
 }: PropsWithChildren<Props>) {
-  if (isServerSide()) {
-    return children
-  }
   const { situation: initialSituationFromUser } = useCurrentSimulation()
   const [situation] = useState(initialSituation ?? initialSituationFromUser)
 

--- a/apps/site/src/publicodes-state/providers/formProvider/provider.tsx
+++ b/apps/site/src/publicodes-state/providers/formProvider/provider.tsx
@@ -84,13 +84,13 @@ export default function FailSafeFormProvider({
 }: PropsWithChildren<{
   root?: DottedName
 }>) {
-  const { safeEvaluate, rules } = useEngine()
+  const { safeEvaluate, rules, engine } = useEngine()
 
   const isRootSafe = useMemo<boolean>(() => {
-    if (!rules) return true
+    if (!rules || !engine) return true
 
     return safeEvaluate(root) ? true : false
-  }, [safeEvaluate, root, rules])
+  }, [safeEvaluate, root, rules, engine])
 
   if (!isRootSafe) {
     notFound()


### PR DESCRIPTION
## Why

Les utilisateurs arrivant sur `/simulateur/bilan` rencontraient l'erreur React "Rendered more hooks than during the previous render" (115 occurrences en 24h sur Sentry).

`EngineProvider` (`apps/site/src/publicodes-state/providers/engineProvider/provider.tsx`) faisait un `return children` anticipé côté serveur avant d'appeler les hooks, avec un `/* eslint-disable react-hooks/rules-of-hooks */` explicite. En SSR : 0 hooks. À l'hydratation : 7 hooks. React levait l'erreur 310 car le compteur de hooks ne correspondait pas entre les deux passes.

## What

Le check `isServerSide()` est conservé mais déplacé **à l'intérieur** des callbacks `useMemo`/`useCallback`, ce qui respecte les Rules of Hooks (le nombre de hooks est identique dans tous les cas). Les fonctions dépendantes de l'engine retournent des valeurs par défaut quand celui-ci n'est pas disponible.

### Changements

| Fichier | Description |
|---------|-------------|
| `provider.tsx` | Suppression du `return children` conditionnel et du `eslint-disable`. Les hooks sont toujours appelés dans le même ordre. |
| `useEngine.ts` | `isServerSide()` vérifié dans le `useMemo` de l'engine → passe le SSR sans initialiser Publicodes. `safeEvaluate` et `safeGetRule` protégés contre un `engine` `undefined`. |
| `useEngineSituation.ts` | `addToEngineSituation` retourne `{} as Situation` quand l'engine est indisponible. |
| `formProvider/provider.tsx` | `FailSafeFormProvider` ignore la validation du `root` (`safeEvaluate`) tant que l'engine n'est pas initialisé, évitant un `notFound()` intempestif au SSR. |

## How tested

- [x] `pnpm run typecheck` — 0 erreur
- [x] ESLint — 0 erreur
- [x] Vérifié visuellement que le flux `/simulateur/bilan` fonctionne correctement

Fixes NOSGESTESCLIMAT-NEXTJS-BB1