### PR TITLE
🐛 fix logout with legacy session

### DIFF
--- a/apps/site/src/services/auth/logout.ts
+++ b/apps/site/src/services/auth/logout.ts
@@ -5,6 +5,7 @@ import { revokeAllSessions } from '@nosgestesclimat/core/features/auth/services/
 import { revalidatePath } from 'next/cache'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
+import { getCookieOptions } from '../../helpers/server/cookie/helpers'
 import { getUserSession } from './get-user-session'
 
 export async function logout(): Promise<void> {
@@ -15,6 +16,18 @@ export async function logout(): Promise<void> {
   }
   for (const cookie of deleteSessionCookies()) {
     cookieStore.delete({ name: cookie.name, ...cookie.options })
+  }
+
+  // Legacy Express-issued auth cookie. Only cleared on an explicit logout —
+  // middlewareMigrateLegacySessions otherwise uses it to transparently
+  // re-issue a session, which is desirable for the token-rotation-failure
+  // paths in auth.middleware.ts but must NOT happen after the user logs out.
+  if (process.env.SERVER_AUTH_COOKIE_NAME) {
+    cookieStore.delete({
+      name: process.env.SERVER_AUTH_COOKIE_NAME,
+      ...getCookieOptions(),
+      maxAge: 0,
+    })
   }
 
   revalidatePath('/', 'layout')


### PR DESCRIPTION
Vu que le logout n'effaçait pas le cookie legacy, le middleware continuait de migrer la session legacy en nouvelle session et donc le logout ne faisait rien.

Je n'ai pas remplacé pour le moment le @tofix qui retire complètement les cookies legacy mais en vrai on pourrait. Ça fait suffisamment longtemps que la nouvelle sécu est en prod.