### PR TITLE
🐛 fix newsletter confirmation origin NGC-3671

### DIFF
--- a/apps/server/scalingo.json
+++ b/apps/server/scalingo.json
@@ -27,6 +27,10 @@
     "SERVER_URL": {
       "generator": "template",
       "template": "https://nosgestesclimat-preprod-pr%PR_NUMBER%.osc-fr1.scalingo.io"
+    },
+    "ORIGIN": {
+      "generator": "template",
+      "template": "https://nosgestesclimat-site-preprod-pr%PR_NUMBER%.osc-fr1.scalingo.io"
     }
   }
 }

--- a/apps/server/scalingo.json
+++ b/apps/server/scalingo.json
@@ -23,6 +23,10 @@
     },
     "DATABASE_READONLY_ANON_ROLES": {
       "value": ""
+    },
+    "SERVER_URL": {
+      "generator": "template",
+      "template": "https://nosgestesclimat-preprod-pr%PR_NUMBER%.osc-fr1.scalingo.io"
     }
   }
 }

--- a/apps/server/src/adapters/brevo/client.ts
+++ b/apps/server/src/adapters/brevo/client.ts
@@ -230,30 +230,6 @@ export const sendVerificationCodeEmail = ({
   })
 }
 
-export const sendAPITokenLinkEmail = ({
-  origin,
-  email,
-  code,
-}: Readonly<{
-  origin: string
-  email: string
-  code: string
-  locale: Locales
-}>) => {
-  const apiTokenUrl = new URL(`${origin}/integrations-api/v1/tokens`)
-  const { searchParams } = apiTokenUrl
-  searchParams.append('code', code)
-  searchParams.append('email', email)
-
-  return sendEmail({
-    email,
-    templateId: TemplateIds[Locales.fr].API_VERIFICATION_CODE,
-    params: {
-      API_TOKEN_URL: apiTokenUrl.toString(),
-    },
-  })
-}
-
 export const sendWelcomeEmail = ({
   email,
   locale,

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -274,8 +274,8 @@ describe('Given a NGC user', () => {
           await EventBus.flush()
         })
 
-        describe('And custom user origin (preprod)', () => {
-          test('Then it sends a welcome email', async () => {
+        describe('And a spoofed origin header', () => {
+          test('Then it ignores it and sends a welcome email using the configured app origin', async () => {
             const { email, code } = await createVerificationCode({
               agent,
               mode: VerificationCodeMode.signUp,
@@ -307,8 +307,7 @@ describe('Given a NGC user', () => {
                   ],
                   templateId: 137,
                   params: {
-                    DASHBOARD_URL:
-                      'https://preprod.nosgestesclimat.fr/mon-espace',
+                    DASHBOARD_URL: 'https://nosgestesclimat.test/mon-espace',
                   },
                 },
               })
@@ -316,7 +315,7 @@ describe('Given a NGC user', () => {
 
             await agent
               .post(url)
-              .set('origin', 'https://preprod.nosgestesclimat.fr')
+              .set('origin', 'https://evil.example.com')
               .send(payload)
               .expect(StatusCodes.OK)
           })

--- a/apps/server/src/features/authentication/authentication.controller.ts
+++ b/apps/server/src/features/authentication/authentication.controller.ts
@@ -43,17 +43,12 @@ router
     validateRequest(LoginValidator),
     async (req, res) => {
       try {
-        const origin =
-          req.get('x-forwarded-origin') ||
-          req.get('origin') ||
-          config.app.origin
         const { token, user } = await login({
           loginDto: req.body,
-          origin,
           locale: req.query.locale,
         })
 
-        res.cookie(COOKIE_NAME, token, getCookieOptions(origin))
+        res.cookie(COOKIE_NAME, token, getCookieOptions(config.app.origin))
 
         return res.status(StatusCodes.OK).json(user)
       } catch (err) {

--- a/apps/server/src/features/authentication/authentication.controller.ts
+++ b/apps/server/src/features/authentication/authentication.controller.ts
@@ -43,7 +43,10 @@ router
     validateRequest(LoginValidator),
     async (req, res) => {
       try {
-        const origin = req.get('origin') || config.app.origin
+        const origin =
+          req.get('x-forwarded-origin') ||
+          req.get('origin') ||
+          config.app.origin
         const { token, user } = await login({
           loginDto: req.body,
           origin,

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -69,11 +69,9 @@ export const verifyCode = async (
 export const login = async ({
   loginDto,
   locale,
-  origin,
 }: {
   loginDto: LoginDto
   locale: Locales
-  origin: string
 }) => {
   const { user, mode, token } = await createAccountOrSignin(loginDto)
 
@@ -82,7 +80,6 @@ export const login = async ({
     previousUserId: loginDto.userId,
     mode,
     locale,
-    origin,
   })
 
   EventBus.emit(loginEvent)

--- a/apps/server/src/features/authentication/events/Login.event.ts
+++ b/apps/server/src/features/authentication/events/Login.event.ts
@@ -9,7 +9,6 @@ export class LoginEvent extends EventBusEvent<{
   previousUserId: string
   mode: VerificationCodeMode
   locale: Locales
-  origin: string
 }> {
   name = 'LoginEvent'
 }

--- a/apps/server/src/features/authentication/events/VerificationCodeCreated.event.ts
+++ b/apps/server/src/features/authentication/events/VerificationCodeCreated.event.ts
@@ -5,7 +5,6 @@ import type { VerificationCodeCreateDto } from '../verification-codes.validator.
 export class VerificationCodeCreatedEvent extends EventBusEvent<{
   verificationCode: VerificationCodeCreateDto & { code: string }
   locale: Locales
-  origin: string
 }> {
   name = 'VerificationCodeCreatedEvent'
 }

--- a/apps/server/src/features/authentication/handlers/send-welcome-email.ts
+++ b/apps/server/src/features/authentication/handlers/send-welcome-email.ts
@@ -1,5 +1,6 @@
 import { sendWelcomeEmail } from '../../../adapters/brevo/client.ts'
 import { VerificationCodeMode } from '../../../adapters/prisma/generated.ts'
+import { config } from '../../../config.ts'
 import type { Handler } from '../../../core/event-bus/handler.ts'
 import type { LoginEvent } from '../events/Login.event.ts'
 
@@ -8,10 +9,9 @@ export const sendBrevoWelcomeEmail: Handler<LoginEvent> = ({
     user: { email },
     mode,
     locale,
-    origin,
   },
 }) => {
   if (mode === VerificationCodeMode.signUp) {
-    return sendWelcomeEmail({ email, origin, locale })
+    return sendWelcomeEmail({ email, origin: config.app.origin, locale })
   }
 }

--- a/apps/server/src/features/authentication/verification-codes.controller.ts
+++ b/apps/server/src/features/authentication/verification-codes.controller.ts
@@ -1,6 +1,5 @@
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
-import { config } from '../../config.ts'
 import { EventBus } from '../../core/event-bus/event-bus.ts'
 import logger from '../../logger.ts'
 import { rateLimitSameRequestMiddleware } from '../../middlewares/rateLimitSameRequestMiddleware.ts'
@@ -32,7 +31,6 @@ router.route('/v1/').post(
     try {
       const verificationCode = await createVerificationCode({
         verificationCodeDto: req.body,
-        origin: req.get('origin') || config.app.origin,
         ...req.query,
       })
       return res.status(StatusCodes.CREATED).json({

--- a/apps/server/src/features/authentication/verification-codes.service.ts
+++ b/apps/server/src/features/authentication/verification-codes.service.ts
@@ -39,11 +39,9 @@ export const generateVerificationCode = async (
 export const createVerificationCode = (
   {
     verificationCodeDto,
-    origin,
     locale,
   }: {
     verificationCodeDto: Pick<VerificationCodeCreateDto, 'email'>
-    origin: string
     locale: Locales
   },
   { session: parentSession }: { session?: Session } = {}
@@ -61,7 +59,6 @@ export const createVerificationCode = (
         code,
       },
       locale,
-      origin,
     })
 
     EventBus.emit(verificationCodeCreatedEvent)

--- a/apps/server/src/features/groups/__tests__/create-group.spec.ts
+++ b/apps/server/src/features/groups/__tests__/create-group.spec.ts
@@ -629,8 +629,8 @@ describe('Given a NGC user', () => {
           await EventBus.flush()
         })
 
-        describe('And custom user origin (preprod)', () => {
-          test('Then it sends a creation email', async () => {
+        describe('And a spoofed origin header', () => {
+          test('Then it ignores it and sends a creation email using the configured app origin', async () => {
             const email = faker.internet.email().toLocaleLowerCase()
             const userId = faker.string.uuid()
             const name = faker.person.fullName()
@@ -661,12 +661,12 @@ describe('Given a NGC user', () => {
                   params: {
                     GROUP_URL: expect.stringMatching(
                       new RegExp(
-                        '^https:\\/\\/preprod\\.nosgestesclimat\\.fr\\/amis\\/resultats\\?groupId=[a-zA-Z0-9_]+&mtm_campaign=email-automatise&mtm_kwd=groupe-admin-voir-classement$'
+                        '^https:\\/\\/nosgestesclimat\\.test\\/amis\\/resultats\\?groupId=[a-zA-Z0-9_]+&mtm_campaign=email-automatise&mtm_kwd=groupe-admin-voir-classement$'
                       )
                     ),
                     SHARE_URL: expect.stringMatching(
                       new RegExp(
-                        '^https:\\/\\/preprod\\.nosgestesclimat\\.fr\\/amis\\/invitation\\?groupId=[a-zA-Z0-9_]+&mtm_campaign=email-automatise&mtm_kwd=groupe-admin-url-partage$'
+                        '^https:\\/\\/nosgestesclimat\\.test\\/amis\\/invitation\\?groupId=[a-zA-Z0-9_]+&mtm_campaign=email-automatise&mtm_kwd=groupe-admin-url-partage$'
                       )
                     ),
 
@@ -681,7 +681,7 @@ describe('Given a NGC user', () => {
             await agent
               .post(url)
               .set(authHeaders({ userId, email }))
-              .set('origin', 'https://preprod.nosgestesclimat.fr')
+              .set('origin', 'https://evil.example.com')
               .send(payload)
               .expect(StatusCodes.CREATED)
 

--- a/apps/server/src/features/groups/groups.controller.ts
+++ b/apps/server/src/features/groups/groups.controller.ts
@@ -1,6 +1,5 @@
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
-import { config } from '../../config.ts'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { ForbiddenException } from '../../core/errors/ForbiddenException.ts'
 import { ImmutableSimulationException } from '../../core/errors/ImmutableSimulationException.ts'
@@ -50,10 +49,6 @@ router
       try {
         const group = await createGroup({
           groupDto: req.body,
-          origin:
-            req.get('x-forwarded-origin') ||
-            req.get('origin') ||
-            config.app.origin,
           user: req.user!,
         })
 
@@ -113,10 +108,6 @@ router
       try {
         const participant = await createParticipant({
           params: req.params,
-          origin:
-            req.get('x-forwarded-origin') ||
-            req.get('origin') ||
-            config.app.origin,
           participantDto: req.body,
           user: req.user!,
         })

--- a/apps/server/src/features/groups/groups.controller.ts
+++ b/apps/server/src/features/groups/groups.controller.ts
@@ -50,7 +50,10 @@ router
       try {
         const group = await createGroup({
           groupDto: req.body,
-          origin: req.get('origin') || config.app.origin,
+          origin:
+            req.get('x-forwarded-origin') ||
+            req.get('origin') ||
+            config.app.origin,
           user: req.user!,
         })
 
@@ -110,7 +113,10 @@ router
       try {
         const participant = await createParticipant({
           params: req.params,
-          origin: req.get('origin') || config.app.origin,
+          origin:
+            req.get('x-forwarded-origin') ||
+            req.get('origin') ||
+            config.app.origin,
           participantDto: req.body,
           user: req.user!,
         })

--- a/apps/server/src/features/groups/groups.service.ts
+++ b/apps/server/src/features/groups/groups.service.ts
@@ -123,11 +123,9 @@ const findGroupAndParticipant = async (
 
 export const createGroup = async ({
   groupDto,
-  origin,
   user,
 }: {
   groupDto: GroupCreateDto
-  origin: string
   user: PartialUser
 }) => {
   const {
@@ -155,7 +153,6 @@ export const createGroup = async ({
   if (simulation) {
     const simulationUpsertedEvent = new SimulationUpsertedEvent({
       group,
-      origin,
       simulation,
       administrator,
       sendEmail: true,
@@ -204,12 +201,10 @@ export const updateGroup = async (
 }
 
 export const createParticipant = async ({
-  origin,
   params,
   participantDto,
   user,
 }: {
-  origin: string
   params: GroupParams
   participantDto: ParticipantCreateDto
   user: PartialUser
@@ -240,7 +235,6 @@ export const createParticipant = async ({
       locale: Locales.fr,
       administrator,
       simulation,
-      origin,
       group,
       user: participantUser,
     })

--- a/apps/server/src/features/integrations/api/authentication/authentication.controller.ts
+++ b/apps/server/src/features/integrations/api/authentication/authentication.controller.ts
@@ -1,5 +1,4 @@
 import { StatusCodes } from 'http-status-codes'
-import { config } from '../../../../config.ts'
 import { EntityNotFoundException } from '../../../../core/errors/EntityNotFoundException.ts'
 import { asyncValidateRequestBody } from '../../../../core/middlewares/asyncValidateRequestBody.ts'
 import { tsRestServer } from '../../../../core/ts-rest.ts'
@@ -15,11 +14,10 @@ import {
 } from './authentication.service.ts'
 
 const router = tsRestServer.router(authenticationContract, {
-  generateApiToken: async ({ body, req }) => {
+  generateApiToken: async ({ body }) => {
     try {
       await generateApiToken({
         generateApiTokenDto: body,
-        origin: req.get('origin') || config.app.origin,
       })
 
       return {

--- a/apps/server/src/features/integrations/api/authentication/authentication.service.ts
+++ b/apps/server/src/features/integrations/api/authentication/authentication.service.ts
@@ -114,10 +114,8 @@ const signTokens = async (email: string) => {
 
 export const generateApiToken = async ({
   generateApiTokenDto: { email },
-  origin,
 }: {
   generateApiTokenDto: GenerateAPITokenRequestDto
-  origin: string
 }) => {
   await transaction(async (session) => {
     const emailWhitelist = await fetchWhitelists(
@@ -132,7 +130,6 @@ export const generateApiToken = async ({
             email,
           },
           locale: Locales.fr,
-          origin,
         },
         { session }
       )

--- a/apps/server/src/features/newsletter/__tests__/confirm-newsletter.spec.ts
+++ b/apps/server/src/features/newsletter/__tests__/confirm-newsletter.spec.ts
@@ -91,8 +91,8 @@ describe('Given a NGC user', () => {
 
   describe('When confirming newsletter subscription', () => {
     describe('And invalid code', () => {
-      test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
-        await agent
+      test(`Then it redirects to an error page with 400 status`, async () => {
+        const response = await agent
           .get(url)
           .query({
             code: 'invalid',
@@ -100,13 +100,17 @@ describe('Given a NGC user', () => {
             origin: 'https://nosgestesclimat.test',
             listIds: [ListIds.MAIN_NEWSLETTER],
           })
-          .expect(StatusCodes.BAD_REQUEST)
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.test/newsletter-confirmation?success=false&status=400'
+        )
       })
     })
 
     describe('And invalid email', () => {
-      test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
-        await agent
+      test(`Then it redirects to an error page with 400 status`, async () => {
+        const response = await agent
           .get(url)
           .query({
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -114,13 +118,17 @@ describe('Given a NGC user', () => {
             origin: 'https://nosgestesclimat.test',
             listIds: [ListIds.MAIN_NEWSLETTER],
           })
-          .expect(StatusCodes.BAD_REQUEST)
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.test/newsletter-confirmation?success=false&status=400'
+        )
       })
     })
 
     describe('And invalid origin (not a valid URL)', () => {
-      test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
-        await agent
+      test('Then it never redirects to the attacker origin, falling back to the default origin', async () => {
+        const response = await agent
           .get(url)
           .query({
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -128,13 +136,17 @@ describe('Given a NGC user', () => {
             origin: 'invalid-origin',
             listIds: [ListIds.MAIN_NEWSLETTER],
           })
-          .expect(StatusCodes.BAD_REQUEST)
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.test/newsletter-confirmation?success=false&status=404'
+        )
       })
     })
 
     describe('And invalid origin (not in allowed origins list)', () => {
-      test('Then it returns a 400 error for malicious domain', async () => {
-        await agent
+      test('Then it never redirects to the malicious domain, falling back to the default origin', async () => {
+        const response = await agent
           .get(url)
           .query({
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -142,11 +154,15 @@ describe('Given a NGC user', () => {
             origin: 'https://malicious-site.com',
             listIds: [ListIds.MAIN_NEWSLETTER],
           })
-          .expect(StatusCodes.BAD_REQUEST)
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.test/newsletter-confirmation?success=false&status=404'
+        )
       })
 
-      test('Then it returns a 400 error for subdomain attack', async () => {
-        await agent
+      test('Then it never redirects to the subdomain attack origin, falling back to the default origin', async () => {
+        const response = await agent
           .get(url)
           .query({
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -154,11 +170,15 @@ describe('Given a NGC user', () => {
             origin: 'https://attacker.nosgestesclimat.test',
             listIds: [ListIds.MAIN_NEWSLETTER],
           })
-          .expect(StatusCodes.BAD_REQUEST)
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.test/newsletter-confirmation?success=false&status=404'
+        )
       })
 
-      test('Then it returns a 400 error for similar domain', async () => {
-        await agent
+      test('Then it never redirects to the similar-looking domain, falling back to the default origin', async () => {
+        const response = await agent
           .get(url)
           .query({
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -166,13 +186,17 @@ describe('Given a NGC user', () => {
             origin: 'https://nosgestesclimat.com', // instead of https://nosgestesclimat.test
             listIds: [ListIds.MAIN_NEWSLETTER],
           })
-          .expect(StatusCodes.BAD_REQUEST)
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.test/newsletter-confirmation?success=false&status=404'
+        )
       })
     })
 
     describe('And invalid listIds (not in allowed newsletters)', () => {
-      test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
-        await agent
+      test(`Then it redirects to an error page with 400 status`, async () => {
+        const response = await agent
           .get(url)
           .query({
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -180,7 +204,62 @@ describe('Given a NGC user', () => {
             origin: 'https://nosgestesclimat.test',
             listIds: [999],
           })
-          .expect(StatusCodes.BAD_REQUEST)
+          .expect(StatusCodes.MOVED_TEMPORARILY)
+
+        expect(response.get('location')).toBe(
+          'https://nosgestesclimat.test/newsletter-confirmation?success=false&status=400'
+        )
+      })
+    })
+
+    describe('And missing listIds (0 newsletters selected)', () => {
+      let email: string
+      let code: string
+
+      beforeEach(async () => {
+        ;({ email, code } = await createNewsletterSubscriptionRequest({
+          agent,
+          listIds: [],
+        }))
+      })
+
+      describe('When clicking the confirmation email link', () => {
+        test('Then it redirects to a success page', async () => {
+          mswServer.use(
+            brevoGetContact(email, {
+              customResponses: [
+                {
+                  body: {
+                    code: 'document_not_found',
+                    message: 'Contact does not exist',
+                  },
+                  status: StatusCodes.NOT_FOUND,
+                },
+              ],
+            }),
+            brevoUpdateContact({
+              expectBody: {
+                email,
+                listIds: [],
+                attributes: {},
+                updateEnabled: true,
+              },
+            })
+          )
+
+          const response = await agent
+            .get(url)
+            .query({
+              code,
+              email,
+              origin: 'https://nosgestesclimat.test',
+            })
+            .expect(StatusCodes.MOVED_TEMPORARILY)
+
+          expect(response.get('location')).toBe(
+            'https://nosgestesclimat.test/newsletter-confirmation?success=true'
+          )
+        })
       })
     })
 

--- a/apps/server/src/features/newsletter/__tests__/inscription-newsletter.spec.ts
+++ b/apps/server/src/features/newsletter/__tests__/inscription-newsletter.spec.ts
@@ -274,8 +274,8 @@ describe('Given a NGC user', () => {
       })
     })
 
-    describe('And custom origin (preprod)', () => {
-      test(`Then it sends a confirmation email with correct origin and returns a ${StatusCodes.OK} response`, async () => {
+    describe('And a spoofed origin header', () => {
+      test(`Then it ignores it and sends a confirmation email using the configured app origin, returning a ${StatusCodes.OK} response`, async () => {
         const email = faker.internet.email().toLocaleLowerCase()
 
         mswServer.use(
@@ -290,7 +290,7 @@ describe('Given a NGC user', () => {
               templateId: 118,
               params: {
                 NEWSLETTER_CONFIRMATION_URL: expect.stringContaining(
-                  encodeURIComponent('https://preprod.nosgestesclimat.fr')
+                  encodeURIComponent('https://nosgestesclimat.test')
                 ),
               },
             },
@@ -299,7 +299,7 @@ describe('Given a NGC user', () => {
 
         const { body } = await agent
           .post(url)
-          .set('origin', 'https://preprod.nosgestesclimat.fr')
+          .set('origin', 'https://evil.example.com')
           .send({
             email,
             listIds: [ListIds.MAIN_NEWSLETTER],

--- a/apps/server/src/features/newsletter/newsletter.controller.ts
+++ b/apps/server/src/features/newsletter/newsletter.controller.ts
@@ -36,8 +36,6 @@ router.route('/v1/inscription').post(
     },
   }),
   async (req, res) => {
-    const origin =
-      req.get('x-forwarded-origin') || req.get('origin') || config.app.origin
     try {
       if (isVerifiedUser(req.user)) {
         if (req.user.email !== req.body.email) {
@@ -52,7 +50,6 @@ router.route('/v1/inscription').post(
       } else {
         await sendNewsletterConfirmationEmail({
           inscriptionDto: req.body,
-          origin,
         })
       }
       return res.status(StatusCodes.OK).json(req.body)

--- a/apps/server/src/features/newsletter/newsletter.controller.ts
+++ b/apps/server/src/features/newsletter/newsletter.controller.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
+import * as v from 'valibot'
 import { config } from '../../config.ts'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { isVerifiedUser } from '../../core/typeguards/isVerifiedUser.ts'
@@ -35,7 +36,8 @@ router.route('/v1/inscription').post(
     },
   }),
   async (req, res) => {
-    const origin = req.get('origin') || config.app.origin
+    const origin =
+      req.get('x-forwarded-origin') || req.get('origin') || config.app.origin
     try {
       if (isVerifiedUser(req.user)) {
         if (req.user.email !== req.body.email) {
@@ -61,37 +63,51 @@ router.route('/v1/inscription').post(
   }
 )
 
-router
-  .route('/v1/confirmation')
-  .get(validateRequest(NewsletterConfirmationValidator), async (req, res) => {
-    const redirectUrl = new URL(req.query.origin)
+router.route('/v1/confirmation').get(async (req, res) => {
+  const parsedQuery = await v.safeParseAsync(
+    NewsletterConfirmationValidator.query,
+    req.query
+  )
+
+  if (!parsedQuery.success) {
+    const redirectUrl = new URL(config.app.origin)
     redirectUrl.pathname = '/newsletter-confirmation'
-    const { searchParams: redirectSearchParams } = redirectUrl
+    redirectUrl.searchParams.append('success', 'false')
+    redirectUrl.searchParams.append(
+      'status',
+      StatusCodes.BAD_REQUEST.toString()
+    )
+    return res.redirect(redirectUrl.toString())
+  }
 
-    try {
-      await confirmNewsletterSubscriptions({
-        query: req.query,
-      })
+  const redirectUrl = new URL(parsedQuery.output.origin)
+  redirectUrl.pathname = '/newsletter-confirmation'
+  const { searchParams: redirectSearchParams } = redirectUrl
 
-      redirectSearchParams.append('success', 'true')
-    } catch (err) {
-      const expired = err instanceof EntityNotFoundException
+  try {
+    await confirmNewsletterSubscriptions({
+      query: parsedQuery.output,
+    })
 
-      if (!expired) {
-        logger.error('Newsletter confirmation failed', err)
-      }
+    redirectSearchParams.append('success', 'true')
+  } catch (err) {
+    const expired = err instanceof EntityNotFoundException
 
-      redirectSearchParams.append('success', 'false')
-      redirectSearchParams.append(
-        'status',
-        (expired
-          ? StatusCodes.NOT_FOUND
-          : StatusCodes.INTERNAL_SERVER_ERROR
-        ).toString()
-      )
+    if (!expired) {
+      logger.error('Newsletter confirmation failed', err)
     }
 
-    return res.redirect(redirectUrl.toString())
-  })
+    redirectSearchParams.append('success', 'false')
+    redirectSearchParams.append(
+      'status',
+      (expired
+        ? StatusCodes.NOT_FOUND
+        : StatusCodes.INTERNAL_SERVER_ERROR
+      ).toString()
+    )
+  }
+
+  return res.redirect(redirectUrl.toString())
+})
 
 export default router

--- a/apps/server/src/features/newsletter/newsletter.service.ts
+++ b/apps/server/src/features/newsletter/newsletter.service.ts
@@ -57,10 +57,8 @@ export const confirmNewsletterSubscriptions = async ({
 
 export const sendNewsletterConfirmationEmail = async ({
   inscriptionDto: { email, listIds },
-  origin,
 }: {
   inscriptionDto: NewsletterInscriptionDto
-  origin: string
 }) => {
   const { code } = await generateVerificationCode({
     verificationCodeDto: { email },
@@ -69,8 +67,8 @@ export const sendNewsletterConfirmationEmail = async ({
 
   return sendNewsLetterConfirmationEmail({
     newsLetterConfirmationBaseUrl: config.app.serverUrl,
+    origin: config.app.origin,
     listIds,
-    origin,
     email,
     code,
   })

--- a/apps/server/src/features/newsletter/newsletter.validator.ts
+++ b/apps/server/src/features/newsletter/newsletter.validator.ts
@@ -1,6 +1,6 @@
 import * as v from 'valibot'
 import { ListIds } from '../../adapters/brevo/constant.ts'
-import { allowedRedirectUrls } from '../../config.ts'
+import { allowedRedirectUrls, config } from '../../config.ts'
 import { isSafeRedirectUrl } from '../../core/allowed-urls.ts'
 import { LocaleQuery } from '../../core/i18n/lang.validator.ts'
 
@@ -49,16 +49,19 @@ export type NewsletterInscriptionDto = v.InferOutput<
 const NewsletterConfirmationQuery = v.strictObject({
   ...LocaleQuery.entries,
   code: v.pipe(v.string(), v.regex(/^\d{6}$/)),
-  origin: v.pipe(
-    v.string(),
-    v.check((url: string) => isSafeRedirectUrl(url, allowedRedirectUrls))
+  origin: v.fallback(
+    v.pipe(
+      v.string(),
+      v.check((url: string) => isSafeRedirectUrl(url, allowedRedirectUrls))
+    ),
+    config.app.origin
   ),
   email: v.pipe(
     v.string(),
     v.email(),
     v.transform((email: string) => email.toLocaleLowerCase())
   ),
-  listIds: ReachableNewsletterListId,
+  listIds: v.optional(ReachableNewsletterListId, []),
 })
 
 export type NewsletterConfirmationQuery = v.InferOutput<

--- a/apps/server/src/features/organisations/__tests__/create-organisation-poll.spec.ts
+++ b/apps/server/src/features/organisations/__tests__/create-organisation-poll.spec.ts
@@ -458,8 +458,8 @@ describe('Given a NGC user', () => {
             .expect(StatusCodes.CREATED)
         })
 
-        describe('And custom user origin (preprod)', () => {
-          test('Then it sends a creation email', async () => {
+        describe('And a spoofed origin header', () => {
+          test('Then it ignores it and sends a creation email using the configured app origin', async () => {
             const payload = {
               name: faker.company.buzzNoun(),
             }
@@ -490,9 +490,9 @@ describe('Given a NGC user', () => {
                   templateId: 126,
                   params: {
                     ADMINISTRATOR_NAME: null,
-                    DASHBOARD_URL: `https://preprod.nosgestesclimat.fr/organisations/${orgaSlug}/campagnes/${pollSlug}?mtm_campaign=email-automatise&mtm_kwd=poll-admin-creation`,
+                    DASHBOARD_URL: `https://nosgestesclimat.test/organisations/${orgaSlug}/campagnes/${pollSlug}?mtm_campaign=email-automatise&mtm_kwd=poll-admin-creation`,
                     POLL_NAME: payload.name,
-                    POLL_URL: `https://preprod.nosgestesclimat.fr/o/${orgaSlug}/${pollSlug}?${searchParams.toString()}`,
+                    POLL_URL: `https://nosgestesclimat.test/o/${orgaSlug}/${pollSlug}?${searchParams.toString()}`,
                   },
                 },
               }),
@@ -504,7 +504,7 @@ describe('Given a NGC user', () => {
               .post(url.replace(':organisationIdOrSlug', organisationId))
               .set(authHeaders({ userId, email }))
               .send(payload)
-              .set('origin', 'https://preprod.nosgestesclimat.fr')
+              .set('origin', 'https://evil.example.com')
               .expect(StatusCodes.CREATED)
           })
         })

--- a/apps/server/src/features/organisations/__tests__/create-organisation.spec.ts
+++ b/apps/server/src/features/organisations/__tests__/create-organisation.spec.ts
@@ -317,8 +317,8 @@ describe('Given a NGC user', () => {
         await EventBus.flush()
       })
 
-      describe('And custom user origin (preprod)', () => {
-        test('Then it sends a creation email', async () => {
+      describe('And a spoofed origin header', () => {
+        test('Then it ignores it and sends a creation email using the configured app origin', async () => {
           const administratorPayload = {
             optedInForCommunications: true,
             name: faker.person.fullName(),
@@ -342,7 +342,7 @@ describe('Given a NGC user', () => {
                 params: {
                   ADMINISTRATOR_NAME: administratorPayload.name,
                   ORGANISATION_NAME: payload.name,
-                  DASHBOARD_URL: `https://preprod.nosgestesclimat.fr/organisations/${slugify.default(payload.name.toLowerCase(), { strict: true })}?mtm_campaign=email-automatise&mtm_kwd=orga-admin-creation`,
+                  DASHBOARD_URL: `https://nosgestesclimat.test/organisations/${slugify.default(payload.name.toLowerCase(), { strict: true })}?mtm_campaign=email-automatise&mtm_kwd=orga-admin-creation`,
                 },
               },
             }),
@@ -354,7 +354,7 @@ describe('Given a NGC user', () => {
             .post(url)
             .set(authHeaders({ userId, email }))
             .send(payload)
-            .set('origin', 'https://preprod.nosgestesclimat.fr')
+            .set('origin', 'https://evil.example.com')
             .expect(StatusCodes.CREATED)
 
           await EventBus.flush()

--- a/apps/server/src/features/organisations/events/OrganisationCreated.event.ts
+++ b/apps/server/src/features/organisations/events/OrganisationCreated.event.ts
@@ -12,7 +12,6 @@ export type OrganisationCreatedEventAttributes = {
   }
   administrator: VerifiedUser
   locale: Locales
-  origin: string
 }
 
 export class OrganisationCreatedEvent extends EventBusEvent<OrganisationCreatedEventAttributes> {

--- a/apps/server/src/features/organisations/events/PollCreated.event.ts
+++ b/apps/server/src/features/organisations/events/PollCreated.event.ts
@@ -12,7 +12,6 @@ export type PollCreatedEventAttributes = {
     administrators: Array<{ user: VerifiedUser }>
   }
   locale: Locales
-  origin: string
   poll: Poll
 }
 

--- a/apps/server/src/features/organisations/handlers/send-organisation-created.ts
+++ b/apps/server/src/features/organisations/handlers/send-organisation-created.ts
@@ -1,7 +1,9 @@
 import { sendOrganisationCreatedEmail } from '../../../adapters/brevo/client.ts'
+import { config } from '../../../config.ts'
 import type { Handler } from '../../../core/event-bus/handler.ts'
 import type { OrganisationCreatedEvent } from '../events/OrganisationCreated.event.ts'
 
 export const sendOrganisationCreated: Handler<OrganisationCreatedEvent> = ({
   attributes,
-}) => sendOrganisationCreatedEmail(attributes)
+}) =>
+  sendOrganisationCreatedEmail({ ...attributes, origin: config.app.origin })

--- a/apps/server/src/features/organisations/handlers/send-poll-created.ts
+++ b/apps/server/src/features/organisations/handlers/send-poll-created.ts
@@ -1,4 +1,5 @@
 import { sendPollCreatedEmail } from '../../../adapters/brevo/client.ts'
+import { config } from '../../../config.ts'
 import type { Handler } from '../../../core/event-bus/handler.ts'
 import type { PollCreatedEvent } from '../events/PollCreated.event.ts'
 
@@ -7,7 +8,6 @@ export const sendPollCreated: Handler<PollCreatedEvent> = (event) => {
     attributes: {
       poll,
       locale,
-      origin,
       organisation,
       organisation: {
         administrators: [{ user: administrator }],
@@ -18,7 +18,7 @@ export const sendPollCreated: Handler<PollCreatedEvent> = (event) => {
   return sendPollCreatedEmail({
     administrator,
     organisation,
-    origin,
+    origin: config.app.origin,
     locale,
     poll,
   })

--- a/apps/server/src/features/organisations/organisations.controller.ts
+++ b/apps/server/src/features/organisations/organisations.controller.ts
@@ -1,6 +1,5 @@
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
-import { config } from '../../config.ts'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { ForbiddenException } from '../../core/errors/ForbiddenException.ts'
 import { ImmutableSimulationException } from '../../core/errors/ImmutableSimulationException.ts'
@@ -73,10 +72,6 @@ router
       try {
         const organisation = await createOrganisation({
           organisationDto: req.body,
-          origin:
-            req.get('x-forwarded-origin') ||
-            req.get('origin') ||
-            config.app.origin,
           locale: req.query.locale,
           user: req.user,
         })
@@ -213,10 +208,6 @@ router
       }
       try {
         const poll = await createPoll({
-          origin:
-            req.get('x-forwarded-origin') ||
-            req.get('origin') ||
-            config.app.origin,
           locale: req.query.locale,
           pollDto: req.body,
           user: req.user,
@@ -420,10 +411,6 @@ router
       try {
         const simulation = await createPollSimulation({
           simulationDto: req.body,
-          origin:
-            req.get('x-forwarded-origin') ||
-            req.get('origin') ||
-            config.app.origin,
           locale: req.query.locale,
           params: req.params,
           user: req.user!,

--- a/apps/server/src/features/organisations/organisations.controller.ts
+++ b/apps/server/src/features/organisations/organisations.controller.ts
@@ -73,7 +73,10 @@ router
       try {
         const organisation = await createOrganisation({
           organisationDto: req.body,
-          origin: req.get('origin') || config.app.origin,
+          origin:
+            req.get('x-forwarded-origin') ||
+            req.get('origin') ||
+            config.app.origin,
           locale: req.query.locale,
           user: req.user,
         })
@@ -210,7 +213,10 @@ router
       }
       try {
         const poll = await createPoll({
-          origin: req.get('origin') || config.app.origin,
+          origin:
+            req.get('x-forwarded-origin') ||
+            req.get('origin') ||
+            config.app.origin,
           locale: req.query.locale,
           pollDto: req.body,
           user: req.user,
@@ -414,7 +420,10 @@ router
       try {
         const simulation = await createPollSimulation({
           simulationDto: req.body,
-          origin: req.get('origin') || config.app.origin,
+          origin:
+            req.get('x-forwarded-origin') ||
+            req.get('origin') ||
+            config.app.origin,
           locale: req.query.locale,
           params: req.params,
           user: req.user!,

--- a/apps/server/src/features/organisations/organisations.service.ts
+++ b/apps/server/src/features/organisations/organisations.service.ts
@@ -120,12 +120,10 @@ const organisationToDto = (
 export const createOrganisation = async ({
   organisationDto,
   locale,
-  origin,
   user,
 }: {
   organisationDto: OrganisationCreateDto
   locale: Locales
-  origin: string
   user: PartialVerifiedUser
 }) => {
   try {
@@ -137,7 +135,6 @@ export const createOrganisation = async ({
       administrator,
       organisation,
       locale,
-      origin,
     })
 
     EventBus.emit(organisationCreatedEvent)
@@ -315,11 +312,9 @@ const pollToDto = ({
 export const createPoll = async ({
   user,
   locale,
-  origin,
   params,
   pollDto,
 }: {
-  origin: string
   params: OrganisationParams
   pollDto: OrganisationPollCreateDto
   user: PartialVerifiedUser
@@ -333,7 +328,6 @@ export const createPoll = async ({
     const pollCreatedEvent = new PollCreatedEvent({
       organisation,
       locale,
-      origin,
       poll,
     })
 

--- a/apps/server/src/features/simulations/__tests__/compute-poll-stats.spec.ts
+++ b/apps/server/src/features/simulations/__tests__/compute-poll-stats.spec.ts
@@ -8,7 +8,6 @@ import { simulationSelection } from '../../../adapters/prisma/selection.ts'
 import { redis } from '../../../adapters/redis/client.ts'
 import { KEYS } from '../../../adapters/redis/constant.ts'
 import app from '../../../app.ts'
-import { config } from '../../../config.ts'
 import { EventBus } from '../../../core/event-bus/event-bus.ts'
 import { Locales } from '../../../core/i18n/constant.ts'
 import logger from '../../../logger.ts'
@@ -92,7 +91,6 @@ describe('Given a poll participation', () => {
       })
 
       event = new SimulationUpsertedAsyncEvent({
-        origin: config.app.origin,
         locale: Locales.fr,
         sendEmail: false,
         updated: false,

--- a/apps/server/src/features/simulations/__tests__/create-poll-simulation.spec.ts
+++ b/apps/server/src/features/simulations/__tests__/create-poll-simulation.spec.ts
@@ -1109,8 +1109,8 @@ describe('Given a NGC user', () => {
           )
         })
 
-        describe('And custom user origin (preprod)', () => {
-          test('Then it sends a creation email', async () => {
+        describe('And a spoofed origin header', () => {
+          test('Then it ignores it and sends a creation email using the configured app origin', async () => {
             const payload: SimulationCreateInputDto = {
               id: faker.string.uuid(),
               model,
@@ -1132,8 +1132,8 @@ describe('Given a NGC user', () => {
                   templateId: 122,
                   params: {
                     ORGANISATION_NAME: organisationName,
-                    DETAILED_VIEW_URL: `https://preprod.nosgestesclimat.fr/organisations/${organisationSlug}/campagnes/${pollSlug}?mtm_campaign=email-automatise&mtm_kwd=orga-invite-campagne`,
-                    SIMULATION_URL: `https://preprod.nosgestesclimat.fr/fin?sid=${payload.id}&mtm_campaign=email-automatise&mtm_kwd=fin-retrouver-simulation`,
+                    DETAILED_VIEW_URL: `https://nosgestesclimat.test/organisations/${organisationSlug}/campagnes/${pollSlug}?mtm_campaign=email-automatise&mtm_kwd=orga-invite-campagne`,
+                    SIMULATION_URL: `https://nosgestesclimat.test/fin?sid=${payload.id}&mtm_campaign=email-automatise&mtm_kwd=fin-retrouver-simulation`,
                   },
                 },
               }),
@@ -1144,7 +1144,7 @@ describe('Given a NGC user', () => {
             await agent
               .post(url.replace(':pollIdOrSlug', pollId))
               .set(authHeaders({ userId, email }))
-              .set('origin', 'https://preprod.nosgestesclimat.fr')
+              .set('origin', 'https://evil.example.com')
               .send(payload)
               .expect(StatusCodes.CREATED)
 

--- a/apps/server/src/features/simulations/events/SimulationUpserted.event.ts
+++ b/apps/server/src/features/simulations/events/SimulationUpserted.event.ts
@@ -23,7 +23,6 @@ export type SimulationEvent = Pick<
 export type SimulationAsyncEvent = SimulationEvent | ModelToDto<SimulationEvent>
 
 type BaseSimulationUpsertedEventAttributes = {
-  origin: string
   locale: Locales
   user: Pick<User, 'id' | 'name' | 'email'>
   simulation: SimulationEvent

--- a/apps/server/src/features/simulations/handlers/send-simulation-upserted.ts
+++ b/apps/server/src/features/simulations/handlers/send-simulation-upserted.ts
@@ -4,13 +4,13 @@ import {
   sendPollSimulationUpsertedEmail,
   sendSimulationUpsertedEmail,
 } from '../../../adapters/brevo/client.ts'
+import { config } from '../../../config.ts'
 import type { Handler } from '../../../core/event-bus/handler.ts'
 import type { SimulationUpsertedEvent } from '../events/SimulationUpserted.event.ts'
 
 export const sendSimulationUpserted: Handler<SimulationUpsertedEvent> = ({
   attributes,
   attributes: {
-    origin,
     user,
     organisation,
     simulation,
@@ -25,6 +25,7 @@ export const sendSimulationUpserted: Handler<SimulationUpsertedEvent> = ({
   }
 
   const { email } = user
+  const origin = config.app.origin
 
   if (simulation?.progression === 1) {
     if (organisation) {

--- a/apps/server/src/features/simulations/simulations.controller.ts
+++ b/apps/server/src/features/simulations/simulations.controller.ts
@@ -61,7 +61,8 @@ router.route('/v1').post(
   validateRequest(SimulationCreateValidator),
   async (req, res) => {
     try {
-      const origin = req.get('origin') || config.app.origin
+      const origin =
+        req.get('x-forwarded-origin') || req.get('origin') || config.app.origin
       const { simulation } = await createSimulation({
         simulationDto: req.body,
         query: req.query,

--- a/apps/server/src/features/simulations/simulations.controller.ts
+++ b/apps/server/src/features/simulations/simulations.controller.ts
@@ -1,6 +1,5 @@
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
-import { config } from '../../config.ts'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { ForbiddenException } from '../../core/errors/ForbiddenException.ts'
 import { ImmutableSimulationException } from '../../core/errors/ImmutableSimulationException.ts'
@@ -61,12 +60,9 @@ router.route('/v1').post(
   validateRequest(SimulationCreateValidator),
   async (req, res) => {
     try {
-      const origin =
-        req.get('x-forwarded-origin') || req.get('origin') || config.app.origin
       const { simulation } = await createSimulation({
         simulationDto: req.body,
         query: req.query,
-        origin,
         user: req.user!,
       })
 

--- a/apps/server/src/features/simulations/simulations.service.ts
+++ b/apps/server/src/features/simulations/simulations.service.ts
@@ -111,12 +111,10 @@ const simulationToDto = (
 export const createSimulation = async ({
   simulationDto,
   query,
-  origin,
   user,
 }: {
   simulationDto: SimulationCreateDto
   query: SimulationCreateQuery
-  origin: string
   user: PartialUser
 }) => {
   const verifiedUser = isVerifiedUser(user) ? user : undefined
@@ -184,7 +182,6 @@ export const createSimulation = async ({
     simulation,
     sendEmail: query.sendEmail,
     locale: query.locale,
-    origin,
   })
 
   EventBus.emit(simulationUpsertedEvent)
@@ -261,12 +258,10 @@ export const softDeleteSimulation = async ({
 
 export const createPollSimulation = async ({
   locale,
-  origin,
   params,
   simulationDto,
   user: requestUser,
 }: {
-  origin: string
   locale: Locales
   params: PublicPollParams
   simulationDto: SimulationCreateDto
@@ -333,7 +328,6 @@ export const createPollSimulation = async ({
       created,
       updated,
       locale,
-      origin,
       poll,
     })
 

--- a/apps/server/src/features/users/events/UserUpdated.event.ts
+++ b/apps/server/src/features/users/events/UserUpdated.event.ts
@@ -4,7 +4,6 @@ import { EventBusEvent } from '../../../core/event-bus/event.ts'
 
 export class UserUpdatedEvent extends EventBusEvent<{
   user: Pick<User, 'id' | 'name' | 'email'>
-  origin: string
   previousContact?: BrevoContact
   nextEmail?: string | null
   verified?: boolean

--- a/apps/server/src/features/users/users.controller.ts
+++ b/apps/server/src/features/users/users.controller.ts
@@ -1,6 +1,5 @@
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
-import { config } from '../../config.ts'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { ForbiddenException } from '../../core/errors/ForbiddenException.ts'
 import { EventBus } from '../../core/event-bus/event-bus.ts'
@@ -56,13 +55,10 @@ router
     validateRequest(UpdateUserValidator),
     async (req, res) => {
       try {
-        const origin = req.get('origin') || config.app.origin
-
         const { user, verified } = await updateUserAndContact({
           user: req.user!,
           code: req.query.code,
           newUserData: req.body,
-          origin,
         })
 
         return verified

--- a/apps/server/src/features/users/users.service.ts
+++ b/apps/server/src/features/users/users.service.ts
@@ -131,12 +131,10 @@ export const updateUserAndContact = async ({
   code,
   user: userToUpdate,
   newUserData,
-  origin,
 }: {
   user: PartialUser
   code?: string
   newUserData: UserUpdateDto
-  origin: string
 }) => {
   const { user, contact, nextEmail, verified, previousContact } =
     await transaction(async (session) => {
@@ -242,7 +240,6 @@ export const updateUserAndContact = async ({
     previousContact,
     nextEmail,
     verified,
-    origin,
     user,
   })
 

--- a/apps/site/src/app/[locale]/newsletter-confirmation/__tests__/NewsletterConfirmationPage.test.tsx
+++ b/apps/site/src/app/[locale]/newsletter-confirmation/__tests__/NewsletterConfirmationPage.test.tsx
@@ -77,6 +77,30 @@ describe('NewsletterConfirmationPage', () => {
     )
   })
 
+  it('should render the invalid message when success=false and status=400', async () => {
+    // Given
+    const props = {
+      params: Promise.resolve({ locale: i18nConfig.defaultLocale as Locale }),
+      searchParams: Promise.resolve({
+        success: 'false' as const,
+        status: '400' as const,
+      }),
+    }
+
+    // When
+    await act(async () => {
+      renderWithWrapper(await NewsletterConfirmationPage(props))
+    })
+
+    // Then
+    expect(NewsletterSuccessMessage).not.toHaveBeenCalled()
+    expect(NewsletterErrorMessage).not.toHaveBeenCalled()
+    expect(NewsletterInvalidMessage).toHaveBeenCalledWith(
+      { locale: i18nConfig.defaultLocale },
+      undefined
+    )
+  })
+
   it('should render the error message when success=false and status=500', async () => {
     // Given
     const props = {

--- a/apps/site/src/app/[locale]/newsletter-confirmation/page.tsx
+++ b/apps/site/src/app/[locale]/newsletter-confirmation/page.tsx
@@ -10,7 +10,7 @@ import NewsletterSuccessMessage from './_components/NewsletterSuccessMessage'
 
 interface SearchParams {
   success: 'true' | 'false'
-  status?: '404' | '500'
+  status?: '400' | '404' | '500'
 }
 
 export const generateMetadata = getCommonMetadata({
@@ -30,7 +30,13 @@ const shouldRedirect404 = ({ success, status }: Partial<SearchParams>) => {
 
   if (success !== 'true' && success !== 'false') return true
 
-  if (success === 'false' && status !== '404' && status !== '500') return true
+  if (
+    success === 'false' &&
+    status !== '400' &&
+    status !== '404' &&
+    status !== '500'
+  )
+    return true
 
   return false
 }
@@ -53,7 +59,7 @@ export default async function NewsletterConfirmationPage({
           <div className="mt-36 text-center">
             {success === 'true' && <NewsletterSuccessMessage locale={locale} />}
 
-            {success === 'false' && status === '404' && (
+            {success === 'false' && (status === '400' || status === '404') && (
               <NewsletterInvalidMessage locale={locale} />
             )}
 

--- a/apps/site/src/helpers/server/fetchServer.ts
+++ b/apps/site/src/helpers/server/fetchServer.ts
@@ -37,6 +37,7 @@ export async function fetchServer<T = unknown>(
   const reqHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
     'x-forwarded-for': nextHeaders.get('x-forwarded-for') ?? '',
+    'x-forwarded-origin': nextHeaders.get('origin') ?? '',
     'x-internal-key': INTERNAL_API_KEY,
   }
 


### PR DESCRIPTION
Étant donné que l'api est interne uniquement (server <> server) le header `origin` n'est plus fourni.

Options :
- passer un header `x-forwarded-origin`
- surcharger `origin` côté site
- fournir la variable d'environnement ORIGIN (déjà supportée) et l'utiliser

J'ai pris la variable d'environnement car je n'ai pas vu le besoin de changer l'origin selon le front qui appelle et ça évite de devoir valider chaque `req.get('origin')` pour la sécu. C'était uniquement utilisé pour les urls dans les emails.

