### PR TITLE
🐛 Fix tutoriel canonical URLs and getLinkToTutoriel path

### DIFF
--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -23,7 +23,23 @@ const nextConfig = withMDX({
   },
   // eslint-disable-next-line @typescript-eslint/require-await
   async redirects() {
-    return redirects
+    const enRedirects = redirects
+      .filter(
+        (r) =>
+          !r.source.startsWith('/en/') &&
+          !r.source.startsWith('/fr/') &&
+          !r.source.startsWith('/es/') &&
+          !r.source.includes('%')
+      )
+      .map((r) => ({
+        ...r,
+        source: `/en${r.source}`,
+        destination: r.destination.startsWith('http')
+          ? r.destination
+          : `/en${r.destination}`,
+      }))
+
+    return [...redirects, ...enRedirects]
   },
   productionBrowserSourceMaps: true,
   turbopack: {

--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -28,7 +28,6 @@ const nextConfig = withMDX({
         (r) =>
           !r.source.startsWith('/en/') &&
           !r.source.startsWith('/fr/') &&
-          !r.source.startsWith('/es/') &&
           !r.source.includes('%')
       )
       .map((r) => ({

--- a/apps/site/src/app/[locale]/simulateur/(header)/tutoriel/layout.tsx
+++ b/apps/site/src/app/[locale]/simulateur/(header)/tutoriel/layout.tsx
@@ -1,4 +1,5 @@
 import { noIndexObject } from '@/constants/metadata'
+import { TUTORIAL_PATH } from '@/constants/urls/paths'
 import { t } from '@/helpers/metadata/fakeMetadataT'
 import { getCommonMetadata } from '@/helpers/metadata/getCommonMetadata'
 import type { PropsWithChildren } from 'react'
@@ -8,7 +9,7 @@ export const generateMetadata = getCommonMetadata({
   description: t(
     'Comprenez comment calculer votre empreinte sur le climat en 10min chrono.'
   ),
-  alternates: { canonical: '/simulateur/tutoriel' },
+  alternates: { canonical: TUTORIAL_PATH },
   robots: noIndexObject,
 })
 


### PR DESCRIPTION
## Why

The tutoriel page at `/simulateur/tutoriel` hardcodes its canonical URL as a string, risking drift on future route changes. The campaign page (previously affected) was already fixed on main with a dynamic canonical.

Additionally, users browsing in English (`/en/`) would get 404s on old URLs that have redirects for the bare path but no `/en/` variant.

## What changed

- **`apps/site/next.config.ts`**: Auto-generates `/en/` variants for every redirect in `redirects.js` that has no locale prefix. This covers `/en/tutoriel` → `/en/simulateur/tutoriel` and all other legacy redirects for English users.

- **`apps/site/src/app/[locale]/simulateur/(header)/tutoriel/layout.tsx`**: Uses `TUTORIAL_PATH` constant instead of hardcoded `/simulateur/tutoriel` in the canonical URL.

### How the `/en/` redirect generation works

Evaluated once at build time. Filters redirects without a locale prefix (`/en/`, `/fr/`) and without URL-encoded characters (`%`), then prepends `/en` to both source and destination. External URLs are left unchanged.