### PR TITLE
🐛 Fix double slashes in sitemap URLs

### DIFF
--- a/src/app/[locale]/sitemap.ts
+++ b/src/app/[locale]/sitemap.ts
@@ -43,7 +43,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ])
 
   const staticUrls = Array.from(staticPages).map((page) => ({
-    url: `https://nosgestesclimat.fr/${page}`,
+    url: `https://nosgestesclimat.fr/${page.replace(/^\//, '')}`,
     lastModified: new Date(),
     priority: 0.8,
   }))


### PR DESCRIPTION
## Pourquoi

Certaines URLs du sitemap contiennent des doubles slashes (ex: `https://nosgestesclimat.fr//mon-espace`), ce qui peut poser des problèmes de SEO. Cela concerne 4 URLs correspondant aux pages de l'espace personnel (`/mon-espace`, `/mon-espace/groupes`, `/mon-espace/actions`, `/mon-espace/parametres`).

Ces chemins sont définis avec un `/` en préfixe dans `@/constants/urls/paths` (ex: `MON_ESPACE_PATH = '/mon-espace'`), ce qui entre en conflit avec le template literal `https://nosgestesclimat.fr/${page}` qui ajoute déjà un `/`.

## Ce qui change

Dans la construction des URLs statiques du sitemap, on retire l'éventuel `/` en début de `page` avec `.replace(/^\//, '')` pour éviter les doubles slashes, quel que soit le format du chemin.

## Comment tester

Vérifier que le sitemap produit l'URL `https://nosgestesclimat.fr/mon-espace` (sans double slash) au lieu de `https://nosgestesclimat.fr//mon-espace`.