### PR TITLE
🩺 Add healthcheck endpoint

### DIFF
--- a/apps/site/src/app/api/health/route.ts
+++ b/apps/site/src/app/api/health/route.ts
@@ -1,0 +1,7 @@
+export const dynamic = 'force-static'
+
+export function GET() {
+  return new Response(JSON.stringify({ status: 'ok' }), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/apps/site/src/proxy.ts
+++ b/apps/site/src/proxy.ts
@@ -63,7 +63,7 @@ export const config = {
      */
     {
       source:
-        '/((?!_next/static|_next/image|favicon.ico|favicon.png|images|manifest.webmanifest|scripts|demos|misc|videos|robots.txt|datashare).*)',
+        '/((?!api|_next/static|_next/image|favicon.ico|favicon.png|images|manifest.webmanifest|scripts|demos|misc|videos|robots.txt|datashare).*)',
     },
   ],
 }


### PR DESCRIPTION
## What

Adds a liveness healthcheck endpoint at `/api/health` for the Next.js app.

## Changes

- **New route** `apps/site/src/app/api/health/route.ts` — static route handler returning `{status: ok}` with `force-static` dynamic config for zero server overhead
- **Matcher update** `apps/site/src/proxy.ts` — excludes `/api` from the proxy middleware so healthcheck requests bypass auth, i18n, and feature flags processing

## Scalingo configuration

After merge, set the Scalingo environment variable:

```
HEALTHCHECK_URL=/api/health
```

This tells Scalingo to ping `/api/health` instead of `/`, avoiding a full page render on each healthcheck.