### PR TITLE
🧱 Add Nginx reverse proxy cache and rate limiting as a CDN replacement

### DIFF
--- a/.github/workflows/infra:nginx-lint.yaml
+++ b/.github/workflows/infra:nginx-lint.yaml
@@ -1,0 +1,51 @@
+name: Nginx config lint
+
+on:
+  pull_request:
+    paths:
+      - 'infra/nginx/**'
+  push:
+    branches: [main]
+    paths:
+      - 'infra/nginx/**'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate nginx.conf.tpl syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install nginx and gettext
+        run: sudo apt-get update && sudo apt-get install -y nginx gettext-base
+
+      - name: Render template with dummy values
+        run: |
+          mkdir -p /tmp/nginx-test
+          DOMAIN=example.com UPSTREAM=example.com \
+            envsubst '${DOMAIN} ${UPSTREAM}' \
+            < infra/nginx/nginx.conf.tpl \
+            > /tmp/nginx-test/site.conf
+
+      - name: Create dummy SSL certs
+        run: |
+          sudo mkdir -p /etc/letsencrypt/live/example.com
+          sudo openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout /etc/letsencrypt/live/example.com/privkey.pem \
+            -out /etc/letsencrypt/live/example.com/fullchain.pem \
+            -days 1 -subj "/CN=localhost" 2>/dev/null
+
+      - name: Validate nginx config
+        run: |
+          cat > /tmp/nginx-test/nginx.conf <<'EOF'
+          events {}
+          http {
+              include /tmp/nginx-test/site.conf;
+          }
+          EOF
+          sudo nginx -t -c /tmp/nginx-test/nginx.conf

--- a/infra/nginx/.gitignore
+++ b/infra/nginx/.gitignore
@@ -1,0 +1,3 @@
+# Ignore cloud-init files for specific environments, except the template
+cloud-init.prod.yaml
+cloud-init.preprod.yaml

--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -1,0 +1,127 @@
+# Infra — nosgestesclimat.fr
+
+Proxy cache Nginx devant l'application Scalingo.
+
+## Architecture
+
+    Navigateur
+      │
+      ▼
+    Instance Scaleway DEV1-S (Nginx)
+      ├── cache (proxy_cache, 500 Mo RAM / 10 Go disque)
+      ├── rate limiting (30 req/s/IP)
+      └── SSL (Let's Encrypt, renouvellement automatique)
+      │
+      ▼
+    nosgestesclimat-site.osc-secnum-fr1.scalingo.io (Scalingo)
+
+## Fichiers
+
+| Fichier                  | Rôle                                                                 |
+| ------------------------ | -------------------------------------------------------------------- |
+| `cloud-init.tpl.yaml`    | Template cloud-init avec placeholders `__DOMAIN__` et `__UPSTREAM__` |
+| `generate-cloud-init.sh` | Génère `cloud-init.preprod.yaml` et `cloud-init.prod.yaml`           |
+| `cloud-init.*.yaml`      | Fichiers générés, prêts à coller dans la console Scaleway            |
+
+## Créer une instance
+
+    ./generate-cloud-init.sh preprod   # ou prod
+
+Puis dans la console Scaleway :
+
+1. **Instances → Create Instance**
+2. Zone : `FR-PAR-1` ou `FR-PAR-2`
+3. Image : `Ubuntu 24.04 LTS`
+4. Type : `DEV1-S`
+5. Volume : `Local Storage` (valeur par défaut)
+6. **Advanced settings → cloud-init** : coller le contenu de `cloud-init.preprod.yaml` (ou `prod`)
+7. Créer l'instance
+
+L'instance démarre. Nginx est configuré mais **arrêté** (le certificat SSL n'existe pas encore).
+
+## Obtenir le certificat SSL
+
+Récupérer l'IP publique dans la console Scaleway, puis :
+
+    ssh root@<ip>
+
+    # Challenge DNS : zéro downtime, le DNS ne bouge pas
+    certbot certonly --manual --preferred-challenges dns \
+      -d preprod.nosgestesclimat.fr
+
+    # → Certbot affiche un TXT record à créer
+    # → Créer le TXT _acme-challenge.preprod.nosgestesclimat.fr
+    # → Vérifier la propagation : dig TXT _acme-challenge.preprod.nosgestesclimat.fr
+    # → Appuyer sur Entrée
+
+    # Certbot configure Nginx et démarre tout
+    certbot --nginx -d preprod.nosgestesclimat.fr
+
+Pour la prod, ajouter `www` :
+
+    certbot certonly --manual --preferred-challenges dns \
+      -d nosgestesclimat.fr -d www.nosgestesclimat.fr
+    certbot --nginx -d nosgestesclimat.fr -d www.nosgestesclimat.fr
+
+## Tester avant bascule DNS
+
+    curl -I --resolve preprod.nosgestesclimat.fr:443:<ip> \
+      https://preprod.nosgestesclimat.fr
+
+    # X-Cache-Status: MISS  (premier appel)
+    # X-Cache-Status: HIT   (deuxième appel — le cache fonctionne)
+
+## Basculer le DNS
+
+Baisser le TTL à 60 secondes, attendre l'expiration de l'ancien TTL, puis :
+
+    preprod.nosgestesclimat.fr  A  <ip-instance>
+    nosgestesclimat.fr          A  <ip-instance>
+    www.nosgestesclimat.fr      CNAME  nosgestesclimat.fr
+
+Une fois le trafic stabilisé, remonter le TTL à 3600.
+
+## Mettre à jour la config Nginx
+
+Modifier `cloud-init.tpl.yaml`, puis appliquer sur l'instance existante :
+
+    # Générer la config mise à jour
+    DOMAIN="nosgestesclimat.fr"
+    UPSTREAM="nosgestesclimat-site.osc-secnum-fr1.scalingo.io"
+    sed "s/__DOMAIN__/$DOMAIN/g; s/__UPSTREAM__/$UPSTREAM/g" \
+      cloud-init.tpl.yaml \
+      | awk '/write_files/,/^$/' \
+      | sed -n '/content: |/,/^  [a-z]/p' \
+      | tail -n +2 | sed 's/^      //' \
+      > /tmp/nginx.conf
+
+    scp /tmp/nginx.conf root@<ip>:/etc/nginx/sites-available/nosgestesclimat
+    ssh root@<ip> "nginx -t && systemctl reload nginx"
+
+Ou, plus simplement, éditer directement sur l'instance :
+
+    ssh root@<ip>
+    nano /etc/nginx/sites-available/nosgestesclimat
+    nginx -t && systemctl reload nginx
+
+Puis reporter les modifications dans `cloud-init.tpl.yaml` pour la prochaine recréation.
+
+## Vérifier le cache
+
+    # Hit ratio sur l'instance
+    tail -100 /var/log/nginx/access.log | grep -c HIT
+
+    # Statut du renouvellement SSL
+    certbot renew --dry-run
+
+    # Timer de renouvellement
+    systemctl status certbot.timer
+
+## Recréer une instance
+
+1. Détruire l'ancienne instance
+2. Créer une nouvelle avec le même cloud-init
+3. Reprendre à « Obtenir le certificat SSL »
+4. Basculer le DNS vers la nouvelle IP si elle a changé
+
+Le cache Nginx repart de zéro mais se repeuple en quelques minutes de trafic.

--- a/infra/nginx/README.md
+++ b/infra/nginx/README.md
@@ -7,21 +7,73 @@ Proxy cache Nginx devant l'application Scalingo.
     Navigateur
       │
       ▼
-    Instance Scaleway DEV1-S (Nginx)
-      ├── cache (proxy_cache, 500 Mo RAM / 10 Go disque)
-      ├── rate limiting (30 req/s/IP)
+    Instance Scaleway (Nginx)
+      ├── cache
+      ├── rate limiting
       └── SSL (Let's Encrypt, renouvellement automatique)
       │
       ▼
     nosgestesclimat-site.osc-secnum-fr1.scalingo.io (Scalingo)
 
-## Fichiers
+## Déploiement pull-based
 
-| Fichier                  | Rôle                                                                 |
-| ------------------------ | -------------------------------------------------------------------- |
-| `cloud-init.tpl.yaml`    | Template cloud-init avec placeholders `__DOMAIN__` et `__UPSTREAM__` |
-| `generate-cloud-init.sh` | Génère `cloud-init.preprod.yaml` et `cloud-init.prod.yaml`           |
-| `cloud-init.*.yaml`      | Fichiers générés, prêts à coller dans la console Scaleway            |
+La conf Nginx est tirée depuis GitHub par chaque instance, toutes les 5 minutes.
+La branche source est configurée via `TEMPLATE_REF` dans `deploy.env`.
+
+    GitHub (TEMPLATE_REF, ex. main)
+      │
+      ├── preprod : tire depuis la branche configurée (canary)
+      │
+      └── prod : tire uniquement si le combined status du commit
+                 est "success" (CI + E2E verts)
+
+Aucun secret en CI, aucune clé SSH dans GitHub Actions, aucune branche
+spécifique. Le gate est le statut CI du commit, vérifié par le script
+de pull lui-même.
+
+### Fichiers
+
+| Fichier                     | Rôle                                                            |
+| --------------------------- | --------------------------------------------------------------- |
+| `nginx.conf.tpl`            | Template Nginx (source de vérité unique, placeholders envsubst) |
+| `pull-config.sh`            | Script de pull (tourne sur l'instance via systemd timer)        |
+| `nginx-config-pull.service` | Unit systemd (oneshot)                                          |
+| `nginx-config-pull.timer`   | Timer systemd (5 min)                                           |
+| `cloud-init.tpl.yaml`       | Template cloud-init (setup machine + first boot)                |
+| `generate-cloud-init.sh`    | Génère `cloud-init.preprod.yaml` et `cloud-init.prod.yaml`      |
+
+### `deploy.env`
+
+Sur chaque instance, `/etc/nginx/deploy.env` contient :
+
+    DOMAIN=preprod.nosgestesclimat.fr
+    UPSTREAM=nosgestesclimat-site-preprod.osc-fr1.scalingo.io
+    ENVIRONMENT=preprod          # preprod ou prod
+    REPO=incubateur-ademe/nosgestesclimat-app
+    TEMPLATE_REF=main            # main ou chore/nginx-proxy-for-cache ou autre
+
+Créé par cloud-init au first boot. Ne change pas ensuite.
+`TEMPLATE_REF` détermine quelle branche/branch le script de pull surveille.
+
+### Modifier la conf Nginx
+
+1. Éditer `nginx.conf.tpl` dans le repo
+2. Ouvrir une PR
+3. Merger sur `main`
+4. Preprod tire dans les 5 min
+5. Le workflow `common:deploy.yaml` déploie l'app + fait tourner les E2E sur preprod
+6. Quand le combined status du commit passe à `success` → prod tire dans les 5 min
+
+Si les E2E échouent : prod ne tire pas. Revert sur `main` → preprod se auto-heal →
+le statut repasse vert → prod tire la version revertée.
+
+### Modifier le pull script ou les units systemd
+
+Ces fichiers sont téléchargés au first boot (via cloud-init `runcmd`) et ne sont
+**pas** auto-updatés ensuite. Pour déployer une correction :
+
+- Soit recréer l'instance (cloud-init télécharge les nouvelles versions)
+- Soit SSH manuel : `curl -fsSL https://raw.githubusercontent.com/incubateur-ademe/nosgestesclimat-app/refs/heads/main/infra/nginx/pull-config.sh -o /usr/local/bin/nginx-config-pull.sh`
 
 ## Créer une instance
 
@@ -37,7 +89,8 @@ Puis dans la console Scaleway :
 6. **Advanced settings → cloud-init** : coller le contenu de `cloud-init.preprod.yaml` (ou `prod`)
 7. Créer l'instance
 
-L'instance démarre. Nginx est configuré mais **arrêté** (le certificat SSL n'existe pas encore).
+L'instance démarre, télécharge la conf Nginx depuis GitHub, mais Nginx reste
+**arrêté** (le certificat SSL n'existe pas encore).
 
 ## Obtenir le certificat SSL
 
@@ -45,7 +98,7 @@ Récupérer l'IP publique dans la console Scaleway, puis :
 
     ssh root@<ip>
 
-    # Challenge DNS : zéro downtime, le DNS ne bouge pas
+    # Certificat initial via challenge DNS (zéro downtime, avant bascule DNS)
     certbot certonly --manual --preferred-challenges dns \
       -d preprod.nosgestesclimat.fr
 
@@ -54,14 +107,29 @@ Récupérer l'IP publique dans la console Scaleway, puis :
     # → Vérifier la propagation : dig TXT _acme-challenge.preprod.nosgestesclimat.fr
     # → Appuyer sur Entrée
 
-    # Certbot configure Nginx et démarre tout
+    # Démarrer Nginx
+    systemctl start nginx
+
+    # Tester, puis basculer le DNS.  Une fois le DNS propagé :
+
+    # Basculer vers l'authenticator nginx (challenge HTTP, renouvellement auto)
     certbot --nginx -d preprod.nosgestesclimat.fr
 
 Pour la prod, ajouter `www` :
 
     certbot certonly --manual --preferred-challenges dns \
       -d nosgestesclimat.fr -d www.nosgestesclimat.fr
+    systemctl start nginx
+    # Après bascule DNS :
     certbot --nginx -d nosgestesclimat.fr -d www.nosgestesclimat.fr
+
+**Important** : `certbot --nginx` peut ajouter quelques lignes dans la conf Nginx
+(bloc challenge HTTP, redirects). Le pull script (5 min) ramènera la conf au
+template. Le certificat reste valide — les fichiers dans
+`/etc/letsencrypt/live/` ne sont pas affectés.
+
+Le renouvellement automatique via `certbot.timer` utilise l'authenticator nginx
+et fonctionne sans intervention.
 
 ## Tester avant bascule DNS
 
@@ -73,55 +141,16 @@ Pour la prod, ajouter `www` :
 
 ## Basculer le DNS
 
-Baisser le TTL à 60 secondes, attendre l'expiration de l'ancien TTL, puis :
-
-    preprod.nosgestesclimat.fr  A  <ip-instance>
-    nosgestesclimat.fr          A  <ip-instance>
-    www.nosgestesclimat.fr      CNAME  nosgestesclimat.fr
-
-Une fois le trafic stabilisé, remonter le TTL à 3600.
-
-## Mettre à jour la config Nginx
-
-Modifier `cloud-init.tpl.yaml`, puis appliquer sur l'instance existante :
-
-    # Générer la config mise à jour
-    DOMAIN="nosgestesclimat.fr"
-    UPSTREAM="nosgestesclimat-site.osc-secnum-fr1.scalingo.io"
-    sed "s/__DOMAIN__/$DOMAIN/g; s/__UPSTREAM__/$UPSTREAM/g" \
-      cloud-init.tpl.yaml \
-      | awk '/write_files/,/^$/' \
-      | sed -n '/content: |/,/^  [a-z]/p' \
-      | tail -n +2 | sed 's/^      //' \
-      > /tmp/nginx.conf
-
-    scp /tmp/nginx.conf root@<ip>:/etc/nginx/sites-available/nosgestesclimat
-    ssh root@<ip> "nginx -t && systemctl reload nginx"
-
-Ou, plus simplement, éditer directement sur l'instance :
-
-    ssh root@<ip>
-    nano /etc/nginx/sites-available/nosgestesclimat
-    nginx -t && systemctl reload nginx
-
-Puis reporter les modifications dans `cloud-init.tpl.yaml` pour la prochaine recréation.
-
 ## Vérifier le cache
 
     # Hit ratio sur l'instance
     tail -100 /var/log/nginx/access.log | grep -c HIT
 
+    # Statut du timer de pull
+    systemctl status nginx-config-pull.timer
+
+    # Dernier pull
+    journalctl -u nginx-config-pull.service --no-pager -n 20
+
     # Statut du renouvellement SSL
     certbot renew --dry-run
-
-    # Timer de renouvellement
-    systemctl status certbot.timer
-
-## Recréer une instance
-
-1. Détruire l'ancienne instance
-2. Créer une nouvelle avec le même cloud-init
-3. Reprendre à « Obtenir le certificat SSL »
-4. Basculer le DNS vers la nouvelle IP si elle a changé
-
-Le cache Nginx repart de zéro mais se repeuple en quelques minutes de trafic.

--- a/infra/nginx/cloud-init.tpl.yaml
+++ b/infra/nginx/cloud-init.tpl.yaml
@@ -1,0 +1,100 @@
+#cloud-config
+# ⚠️  Ne pas éditer directement. Généré par ./generate-cloud-init.sh
+#     Template : cloud-init.tpl.yaml
+
+package_update: true
+package_upgrade: true
+
+packages:
+  - nginx
+  - certbot
+  - python3-certbot-nginx
+
+write_files:
+  - path: /etc/nginx/sites-available/nosgestesclimat
+    permissions: '0644'
+    content: |
+      limit_req_zone $binary_remote_addr zone=web:10m rate=30r/s;
+      limit_req_status 429;
+
+      proxy_cache_path /var/cache/nginx levels=1:2
+                       keys_zone=ngc_cache:500m
+                       max_size=30g inactive=1d use_temp_path=off;
+
+      map $cookie_ngc_session $ngc_auth {
+          ""       "anon";
+          default  "auth";
+      }
+
+      upstream scalingo {
+          server __UPSTREAM__:443;
+          keepalive 64;
+      }
+
+      server {
+          listen 80 default_server;
+          listen [::]:80 default_server;
+          server_name _;
+
+          return 301 https://$host$request_uri;
+      }
+
+      server {
+          listen 443 ssl;
+          listen [::]:443 ssl;
+          server_name www.__DOMAIN__;
+
+          http2 on;
+
+          ssl_certificate     /etc/letsencrypt/live/__DOMAIN__/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/__DOMAIN__/privkey.pem;
+
+          return 301 https://__DOMAIN__$request_uri;
+      }
+
+      server {
+          listen 443 ssl;
+          listen [::]:443 ssl;
+          server_name __DOMAIN__;
+
+          http2 on;
+
+          ssl_certificate     /etc/letsencrypt/live/__DOMAIN__/fullchain.pem;
+          ssl_certificate_key /etc/letsencrypt/live/__DOMAIN__/privkey.pem;
+
+          add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+          add_header X-Cache-Status $upstream_cache_status;
+
+          proxy_set_header Host $host;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto https;
+          proxy_cache ngc_cache;
+          proxy_cache_use_stale error timeout updating
+                              http_500 http_502 http_503 http_504;
+
+          location /_next/static/ {
+              proxy_pass https://scalingo;
+              proxy_cache_key "$scheme$request_method$host$request_uri";
+              proxy_cache_valid 200 365d;
+          }
+
+          location / {
+              proxy_pass https://scalingo;
+              limit_req zone=web burst=20 nodelay;
+
+              proxy_cache_key "$scheme$request_method$host$request_uri$ngc_auth";
+              proxy_cache_valid 200 60s;
+              proxy_cache_lock on;
+              proxy_cache_background_update on;
+          }
+      }
+
+runcmd:
+  - mkdir -p /var/cache/nginx
+  - chown -R www-data:www-data /var/cache/nginx
+  - ln -sf /etc/nginx/sites-available/nosgestesclimat /etc/nginx/sites-enabled/
+  - rm -f /etc/nginx/sites-enabled/default
+  - ufw allow 22/tcp && ufw allow 80/tcp && ufw allow 443/tcp && ufw --force enable
+  - echo "✅ Nginx config prête (Nginx à l'arrêt — certificat manquant)."
+  - echo "   certbot certonly --manual --preferred-challenges dns -d __DOMAIN__ -d www.__DOMAIN__"

--- a/infra/nginx/cloud-init.tpl.yaml
+++ b/infra/nginx/cloud-init.tpl.yaml
@@ -9,92 +9,31 @@ packages:
   - nginx
   - certbot
   - python3-certbot-nginx
+  - gettext-base
+  - jq
 
 write_files:
-  - path: /etc/nginx/sites-available/nosgestesclimat
-    permissions: '0644'
+  - path: /etc/nginx/deploy.env
+    permissions: '0600'
     content: |
-      limit_req_zone $binary_remote_addr zone=web:10m rate=30r/s;
-      limit_req_status 429;
-
-      proxy_cache_path /var/cache/nginx levels=1:2
-                       keys_zone=ngc_cache:500m
-                       max_size=30g inactive=1d use_temp_path=off;
-
-      map $cookie_ngc_session $ngc_auth {
-          ""       "anon";
-          default  "auth";
-      }
-
-      upstream scalingo {
-          server __UPSTREAM__:443;
-          keepalive 64;
-      }
-
-      server {
-          listen 80 default_server;
-          listen [::]:80 default_server;
-          server_name _;
-
-          return 301 https://$host$request_uri;
-      }
-
-      server {
-          listen 443 ssl;
-          listen [::]:443 ssl;
-          server_name www.__DOMAIN__;
-
-          http2 on;
-
-          ssl_certificate     /etc/letsencrypt/live/__DOMAIN__/fullchain.pem;
-          ssl_certificate_key /etc/letsencrypt/live/__DOMAIN__/privkey.pem;
-
-          return 301 https://__DOMAIN__$request_uri;
-      }
-
-      server {
-          listen 443 ssl;
-          listen [::]:443 ssl;
-          server_name __DOMAIN__;
-
-          http2 on;
-
-          ssl_certificate     /etc/letsencrypt/live/__DOMAIN__/fullchain.pem;
-          ssl_certificate_key /etc/letsencrypt/live/__DOMAIN__/privkey.pem;
-
-          add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
-          add_header X-Cache-Status $upstream_cache_status;
-
-          proxy_set_header Host $host;
-          proxy_set_header X-Forwarded-Host $host;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto https;
-          proxy_cache ngc_cache;
-          proxy_cache_use_stale error timeout updating
-                              http_500 http_502 http_503 http_504;
-
-          location /_next/static/ {
-              proxy_pass https://scalingo;
-              proxy_cache_key "$scheme$request_method$host$request_uri";
-              proxy_cache_valid 200 365d;
-          }
-
-          location / {
-              proxy_pass https://scalingo;
-              limit_req zone=web burst=20 nodelay;
-
-              proxy_cache_key "$scheme$request_method$host$request_uri$ngc_auth";
-              proxy_cache_valid 200 60s;
-              proxy_cache_lock on;
-              proxy_cache_background_update on;
-          }
-      }
+      DOMAIN=__DOMAIN__
+      UPSTREAM=__UPSTREAM__
+      ENVIRONMENT=__ENVIRONMENT__
+      REPO=__REPO__
+      TEMPLATE_REF=__TEMPLATE_REF__
 
 runcmd:
-  - mkdir -p /var/cache/nginx
+  - mkdir -p /var/cache/nginx /var/lib/nginx-config
   - chown -R www-data:www-data /var/cache/nginx
   - ln -sf /etc/nginx/sites-available/nosgestesclimat /etc/nginx/sites-enabled/
   - rm -f /etc/nginx/sites-enabled/default
   - ufw allow 22/tcp && ufw allow 80/tcp && ufw allow 443/tcp && ufw --force enable
-  - echo "✅ Nginx config prête (Nginx à l'arrêt — certificat manquant)."
+  - curl -fsSL https://raw.githubusercontent.com/__REPO__/refs/heads/__TEMPLATE_REF__/infra/nginx/pull-config.sh -o /usr/local/bin/nginx-config-pull.sh
+  - chmod +x /usr/local/bin/nginx-config-pull.sh
+  - curl -fsSL https://raw.githubusercontent.com/__REPO__/refs/heads/__TEMPLATE_REF__/infra/nginx/nginx-config-pull.service -o /etc/systemd/system/nginx-config-pull.service
+  - curl -fsSL https://raw.githubusercontent.com/__REPO__/refs/heads/__TEMPLATE_REF__/infra/nginx/nginx-config-pull.timer -o /etc/systemd/system/nginx-config-pull.timer
+  - systemctl daemon-reload
+  - systemctl enable --now nginx-config-pull.timer
+  - /usr/local/bin/nginx-config-pull.sh
+  - echo "✅ Nginx config pulled. Nginx à l'arrêt — certificat SSL manquant."
   - echo "   certbot certonly --manual --preferred-challenges dns -d __DOMAIN__ -d www.__DOMAIN__"

--- a/infra/nginx/generate-cloud-init.sh
+++ b/infra/nginx/generate-cloud-init.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Usage : ./generate-cloud-init.sh preprod|prod
+
+ENV=${1:?Usage: ./generate-cloud-init.sh preprod|prod}
+
+case $ENV in
+  preprod)
+    DOMAIN="preprod.nosgestesclimat.fr"
+    UPSTREAM="nosgestesclimat-site-preprod.osc-fr1.scalingo.io"
+    ;;
+  prod)
+    DOMAIN="nosgestesclimat.fr"
+    UPSTREAM="nosgestesclimat-site.osc-secnum-fr1.scalingo.io"
+    ;;
+  *)
+    echo "Usage: ./generate-cloud-init.sh preprod|prod"
+    exit 1
+    ;;
+esac
+
+
+# Create the output file path
+OUTPUT_FILE="cloud-init.$ENV.yaml"
+
+# Check if the template file exists
+if [ ! -f "cloud-init.tpl.yaml" ]; then
+    echo "❌ Error: cloud-init.tpl.yaml template file not found!" >&2
+    exit 1
+fi
+
+# Perform the substitution and write to the output file
+if ! sed "s/__DOMAIN__/$DOMAIN/g; s/__UPSTREAM__/$UPSTREAM/g" cloud-init.tpl.yaml > "$OUTPUT_FILE"; then
+    echo "❌ Error: Failed to generate $OUTPUT_FILE" >&2
+    exit 1
+fi
+
+echo "✅ infra/$OUTPUT_FILE généré"

--- a/infra/nginx/generate-cloud-init.sh
+++ b/infra/nginx/generate-cloud-init.sh
@@ -3,14 +3,21 @@
 
 ENV=${1:?Usage: ./generate-cloud-init.sh preprod|prod}
 
+REPO="incubateur-ademe/nosgestesclimat-app"
+
 case $ENV in
   preprod)
     DOMAIN="preprod.nosgestesclimat.fr"
     UPSTREAM="nosgestesclimat-site-preprod.osc-fr1.scalingo.io"
+    ENVIRONMENT="preprod"
+    # @TODO change to main once the branch is merged.
+    TEMPLATE_REF="chore/nginx-proxy-for-cache"
     ;;
   prod)
     DOMAIN="nosgestesclimat.fr"
     UPSTREAM="nosgestesclimat-site.osc-secnum-fr1.scalingo.io"
+    ENVIRONMENT="prod"
+    TEMPLATE_REF="main"
     ;;
   *)
     echo "Usage: ./generate-cloud-init.sh preprod|prod"
@@ -18,18 +25,15 @@ case $ENV in
     ;;
 esac
 
-
-# Create the output file path
 OUTPUT_FILE="cloud-init.$ENV.yaml"
 
-# Check if the template file exists
 if [ ! -f "cloud-init.tpl.yaml" ]; then
     echo "❌ Error: cloud-init.tpl.yaml template file not found!" >&2
     exit 1
 fi
 
-# Perform the substitution and write to the output file
-if ! sed "s/__DOMAIN__/$DOMAIN/g; s/__UPSTREAM__/$UPSTREAM/g" cloud-init.tpl.yaml > "$OUTPUT_FILE"; then
+if ! sed "s|__DOMAIN__|$DOMAIN|g; s|__UPSTREAM__|$UPSTREAM|g; s|__ENVIRONMENT__|$ENVIRONMENT|g; s|__REPO__|$REPO|g; s|__TEMPLATE_REF__|$TEMPLATE_REF|g" \
+    cloud-init.tpl.yaml > "$OUTPUT_FILE"; then
     echo "❌ Error: Failed to generate $OUTPUT_FILE" >&2
     exit 1
 fi

--- a/infra/nginx/generate-cloud-init.sh
+++ b/infra/nginx/generate-cloud-init.sh
@@ -10,8 +10,7 @@ case $ENV in
     DOMAIN="preprod.nosgestesclimat.fr"
     UPSTREAM="nosgestesclimat-site-preprod.osc-fr1.scalingo.io"
     ENVIRONMENT="preprod"
-    # @TODO change to main once the branch is merged.
-    TEMPLATE_REF="chore/nginx-proxy-for-cache"
+    TEMPLATE_REF="main"
     ;;
   prod)
     DOMAIN="nosgestesclimat.fr"

--- a/infra/nginx/nginx-config-pull.service
+++ b/infra/nginx/nginx-config-pull.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Pull and apply Nginx config from GitHub
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/nginx-config-pull.sh
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/nginx/nginx-config-pull.timer
+++ b/infra/nginx/nginx-config-pull.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pull Nginx config from GitHub every 5 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -1,0 +1,80 @@
+limit_req_zone $binary_remote_addr zone=web:10m rate=30r/s;
+limit_req_status 429;
+
+proxy_cache_path /var/cache/nginx levels=1:2
+                 keys_zone=ngc_cache:500m
+                 max_size=30g inactive=3d use_temp_path=off;
+
+map $cookie_ngc_session $ngc_auth {
+    ""       "anon";
+    default  "auth";
+}
+
+upstream scalingo {
+    server ${UPSTREAM}:443;
+    keepalive 64;
+}
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name www.${DOMAIN};
+
+
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+
+    return 301 https://${DOMAIN}$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${DOMAIN};
+
+
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Cache-Status $upstream_cache_status;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_cache ngc_cache;
+    proxy_cache_use_stale error timeout updating
+                          http_500 http_502 http_503 http_504;
+
+    location /_next/static/ {
+        proxy_pass https://scalingo;
+        proxy_cache_lock on;
+    }
+
+    location ~ ^/(_next/image|images|misc|fonts)/ {
+        proxy_pass https://scalingo;
+        proxy_cache_valid 200 30d;
+        proxy_cache_lock on;
+    }
+
+    location / {
+        proxy_pass https://scalingo;
+        limit_req zone=web burst=20 nodelay;
+
+        proxy_cache_key "$scheme$request_method$host$request_uri$ngc_auth";
+        proxy_cache_lock on;
+        proxy_cache_background_update on;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/infra/nginx/pull-config.sh
+++ b/infra/nginx/pull-config.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+# ─── Configuration ──────────────────────────────────────────────
+DEPLOY_ENV="/etc/nginx/deploy.env"
+NGINX_CONF="/etc/nginx/sites-available/nosgestesclimat"
+BACKUP_CONF="${NGINX_CONF}.bak"
+STATE_DIR="/var/lib/nginx-config"
+LAST_SHA_FILE="${STATE_DIR}/last-sha"
+GITHUB_RAW="https://raw.githubusercontent.com"
+GITHUB_API="https://api.github.com"
+
+# ─── Load environment ───────────────────────────────────────────
+if [ ! -f "$DEPLOY_ENV" ]; then
+    echo "ERROR: $DEPLOY_ENV not found"
+    exit 1
+fi
+# shellcheck source=/dev/null
+source "$DEPLOY_ENV"
+export DOMAIN UPSTREAM ENVIRONMENT REPO TEMPLATE_REF
+
+: "${DOMAIN:?DOMAIN must be set in $DEPLOY_ENV}"
+: "${UPSTREAM:?UPSTREAM must be set in $DEPLOY_ENV}"
+: "${ENVIRONMENT:?ENVIRONMENT must be set in $DEPLOY_ENV}"
+: "${REPO:?REPO must be set in $DEPLOY_ENV}"
+: "${TEMPLATE_REF:?TEMPLATE_REF must be set in $DEPLOY_ENV}"
+
+mkdir -p "$STATE_DIR"
+
+# ─── Get latest commit SHA ───────────────────────────────────────
+SHA=$(curl -fsSL --max-time 30 --retry 3 \
+    -H "Accept: application/vnd.github+json" \
+    -H "User-Agent: nginx-config-pull" \
+    "${GITHUB_API}/repos/${REPO}/git/refs/heads/${TEMPLATE_REF}" \
+    | jq -r '.object.sha')
+
+if [ -z "$SHA" ] || [ "$SHA" = "null" ]; then
+    echo "ERROR: could not fetch latest SHA from GitHub"
+    exit 1
+fi
+
+# ─── Skip if already up to date ─────────────────────────────────
+if [ -f "$LAST_SHA_FILE" ] && [ "$(cat "$LAST_SHA_FILE")" = "$SHA" ]; then
+    exit 0
+fi
+
+# ─── Prod gate: check combined CI status ────────────────────────
+if [ "$ENVIRONMENT" = "prod" ]; then
+    STATE=$(curl -fsSL --max-time 30 --retry 3 \
+        -H "Accept: application/vnd.github+json" \
+        -H "User-Agent: nginx-config-pull" \
+        "${GITHUB_API}/repos/${REPO}/commits/${SHA}/status" \
+        | jq -r '.state')
+
+    if [ "$STATE" != "success" ]; then
+        echo "SKIP: commit ${SHA:0:7} has status '${STATE}' — waiting for CI"
+        exit 0
+    fi
+fi
+
+# ─── Download template ──────────────────────────────────────────
+TMP_TEMPLATE=$(mktemp)
+TMP_RENDERED=$(mktemp)
+trap 'rm -f "$TMP_TEMPLATE" "$TMP_RENDERED"' EXIT
+
+if ! curl -fsSL --max-time 30 --retry 3 \
+    -H "User-Agent: nginx-config-pull" \
+    "${GITHUB_RAW}/${REPO}/refs/heads/${TEMPLATE_REF}/infra/nginx/nginx.conf.tpl" \
+    -o "$TMP_TEMPLATE"; then
+    echo "ERROR: failed to download nginx.conf.tpl"
+    exit 1
+fi
+
+# Validate: non-empty and looks like Nginx config (not a GitHub 404 HTML page)
+if [ ! -s "$TMP_TEMPLATE" ] || ! head -1 "$TMP_TEMPLATE" | grep -qv '^<!DOCTYPE'; then
+    echo "ERROR: downloaded template is empty or not a valid config file"
+    exit 1
+fi
+
+# ─── Render ─────────────────────────────────────────────────────
+envsubst '${DOMAIN} ${UPSTREAM}' < "$TMP_TEMPLATE" > "$TMP_RENDERED"
+
+# ─── Skip if rendered config is identical ───────────────────────
+if [ -f "$NGINX_CONF" ] && cmp -s "$NGINX_CONF" "$TMP_RENDERED"; then
+    echo "$SHA" > "$LAST_SHA_FILE"
+    exit 0
+fi
+
+# ─── Backup + install ───────────────────────────────────────────
+if [ -f "$NGINX_CONF" ]; then
+    cp "$NGINX_CONF" "$BACKUP_CONF"
+fi
+cp "$TMP_RENDERED" "$NGINX_CONF"
+
+# ─── Validate + reload ──────────────────────────────────────────
+# Invariant: if nginx is running, SSL certs exist (the config references them
+# and nginx can't start without them). So we gate on nginx being active.
+if ! systemctl is-active --quiet nginx; then
+    echo "OK: config installed (nginx not running yet — commit ${SHA:0:7})"
+    echo "$SHA" > "$LAST_SHA_FILE"
+    exit 0
+fi
+
+if ! nginx -t 2>&1; then
+    echo "ERROR: nginx -t failed"
+    if [ -f "$BACKUP_CONF" ]; then
+        cp "$BACKUP_CONF" "$NGINX_CONF"
+        echo "Rolled back to previous config"
+    fi
+    exit 1
+fi
+
+systemctl reload nginx
+
+# ─── Health check ───────────────────────────────────────────────
+if ! curl -fsS --max-time 10 \
+    --resolve "${DOMAIN}:443:127.0.0.1" \
+    "https://${DOMAIN}/" -o /dev/null; then
+    echo "ERROR: health check failed after reload — rolling back"
+    cp "$BACKUP_CONF" "$NGINX_CONF"
+    systemctl reload nginx
+    exit 1
+fi
+
+echo "OK: config deployed and nginx reloaded (commit ${SHA:0:7})"
+echo "$SHA" > "$LAST_SHA_FILE"


### PR DESCRIPTION
## Why

nosgestesclimat.fr needs to absorb 35K req/min traffic spikes (newsletters, media coverage) without crashing the Scalingo origin. A scalable CDN layer was planned but mandatory Scaleway Load Balancer (LB-GP-L at 68 €/month) and Edge Services prove costly and complex.

Instead, a single Scaleway DEV1-S instance running Nginx achieves the same result: HTTP caching, rate limiting, SSL termination, and HSTS — at ~6.50 €/month with full French sovereignty.

## What changed

### Nginx reverse proxy config (`infra/nginx/nginx.conf.tpl`)

Single-source-of-truth template rendered with `envsubst`.  Placeholders `${DOMAIN}` and `${UPSTREAM}` only — no other variables touched.

- `proxy_cache` in /var/cache/nginx (keys_zone=500m, max_size=30g, inactive=3d)
- Auth-aware cache key (`$ngc_auth`) mapped from session cookie for `location /` — static assets use default Nginx key
- `limit_req` rate limiting at 30 req/s/IP, burst=20
- Dedicated location blocks:
  - `/_next/static/` — cache lock, no TTL (honors upstream Next.js immutable headers)
  - `/_next/image/` + `/images/` + `/misc/` + `/fonts/` — 30d TTL, cache lock
- HTTP→HTTPS redirect, www→apex redirect, HSTS
- Websocket upgrade headers + cache bypass
- `http2` via listen directive (compatible nginx 1.9.5 and 1.28+)

### Pull-based deployment (`infra/nginx/pull-config.sh`)

No SSH keys in CI, no Ansible, no extra branches.  Each instance pulls the config from GitHub every 5 minutes via systemd timer.

- Preprod pulls from configured branch immediately (canary)
- Prod pulls only when the GitHub combined status of the commit is `success` (CI + E2E green)
- `envsubst` rendering → `nginx -t` validation → `systemctl reload` → health check → auto-rollback on failure
- `/etc/nginx/deploy.env` per instance (DOMAIN, UPSTREAM, ENVIRONMENT, REPO, TEMPLATE_REF)

### Systemd units

- `nginx-config-pull.service` — oneshot, TimeoutStartSec=120
- `nginx-config-pull.timer` — OnBootSec=1min, OnUnitActiveSec=5min, Persistent=true

### Cloud-init (`infra/nginx/cloud-init.tpl.yaml`)

Provisioning for Ubuntu 24.04 — installs Nginx, certbot (+ nginx plugin), gettext-base, jq.  Writes `deploy.env`, downloads pull script + systemd units from GitHub at first boot, enables timer.

### CI validation (`.github/workflows/infra:nginx-lint.yaml`)

On every PR touching `infra/nginx/**`: renders the template with dummy values, creates fake SSL certs, runs `nginx -t`.

### SSL

Two-step process:
1. Initial cert via DNS challenge (`certbot certonly --manual`) — zero downtime before DNS switch
2. After DNS switch: `certbot --nginx` for HTTP challenge auto-renewal

## How verified

- `curl -I --resolve` against the live preprod instance confirms:
  - `X-Cache-Status: MISS` on first request, `HIT` on second
  - Correct `Cache-Control` headers from the origin
  - Working HTTP→HTTPS and www→apex redirects
  - HSTS header present
  - Rate limiting active (429 on burst overflow)
- Pull script tested manually on preprod instance
- CI lint workflow validates config syntax on every push