### PR TITLE
⚡️ Migre experimental.useCache vers cacheComponents

### DIFF
--- a/.github/workflows/infra:nginx-lint.yaml
+++ b/.github/workflows/infra:nginx-lint.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   validate:
     name: Validate nginx.conf.tpl syntax
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
 
     steps:

--- a/apps/site/e2e/features/groups.spec.ts
+++ b/apps/site/e2e/features/groups.spec.ts
@@ -42,7 +42,9 @@ test.describe('A group admin', () => {
       await newGroup.delete()
       await page.waitForTimeout(2200)
       await expect(page).toHaveURL('/mon-espace/groupes')
-      await expect(page.getByText(newGroup.name)).toBeHidden()
+      await expect(
+        page.getByText(newGroup.name).filter({ visible: true })
+      ).toHaveCount(0)
     })
   })
 
@@ -61,7 +63,7 @@ test.describe('The group result page, when accessed by an admin', () => {
   })
 
   test('displays group name in h1', async ({ group, page }) => {
-    await expect(page.locator('h1')).toHaveText(group.name)
+    await expect(page.getByTestId('group-name')).toHaveText(group.name)
   })
 
   test('has an invite link that can be copied with good utm', async ({
@@ -214,13 +216,13 @@ test.describe('A user with a completed test that joined a group', () => {
 
   test('see the group result page after joining', async ({ group }) => {
     await expect(page).toHaveURL(group.url)
-    await expect(page.locator('h1')).toContainText(group.name)
+    await expect(page.getByTestId('group-name')).toContainText(group.name)
   })
 
   test('can access the group result page directly', async ({ group }) => {
     await page.goto(group.url)
     await expect(page).toHaveURL(group.url)
-    await expect(page.locator('h1')).toContainText(group.name)
+    await expect(page.getByTestId('group-name')).toContainText(group.name)
   })
 
   test('can go to the group from the end page of his test', async ({
@@ -229,14 +231,14 @@ test.describe('A user with a completed test that joined a group', () => {
     await page.goto('/fin')
     await page.getByTestId('see-group-result-button').click()
     await expect(page).toHaveURL(group.url)
-    await expect(page.locator('h1')).toContainText(group.name)
+    await expect(page.getByTestId('group-name')).toContainText(group.name)
   })
 
   test('can see the group in the « mes groupes » tab', async ({ group }) => {
     await page.goto('/fin')
     await group.goFromGroupTabs(page)
     await expect(page).toHaveURL(group.url)
-    await expect(page.locator('h1')).toContainText(group.name)
+    await expect(page.getByTestId('group-name')).toContainText(group.name)
   })
 
   test('when he reuses the invite link, lands directly on the result page', async ({
@@ -244,14 +246,21 @@ test.describe('A user with a completed test that joined a group', () => {
   }) => {
     await page.goto(group.inviteLink)
     await expect(page).toHaveURL(group.url)
-    await expect(page.locator('h1')).toContainText(group.name)
+    await expect(page.getByTestId('group-name')).toContainText(group.name)
   })
 
   test('can leave a group', async ({ group }) => {
+    // Navigate away then back to force a fresh mount of /amis/resultats.
+    // Without this, the previous <Activity> keeps its React state across
+    // tests and the leave-button click does not open the confirmation modal.
+    await page.goto('/fin')
     await page.goto(group.url)
+    await expect(page.getByTestId('button-leave-group')).toBeVisible()
     await group.leave(page)
     await page.goto('/fin')
     await page.getByTestId('my-groups-tab').click()
-    await expect(page.getByText(group.name)).toBeHidden()
+    await expect(
+      page.getByText(group.name).filter({ visible: true })
+    ).toHaveCount(0)
   })
 })

--- a/apps/site/e2e/features/groups.spec.ts
+++ b/apps/site/e2e/features/groups.spec.ts
@@ -250,11 +250,6 @@ test.describe('A user with a completed test that joined a group', () => {
   })
 
   test('can leave a group', async ({ group }) => {
-    // Navigate away then back to force a fresh mount of /amis/resultats.
-    // Without this, the previous <Activity> keeps its React state across
-    // tests and the leave-button click does not open the confirmation modal.
-    await page.goto('/fin')
-    await page.goto(group.url)
     await expect(page.getByTestId('button-leave-group')).toBeVisible()
     await group.leave(page)
     await page.goto('/fin')

--- a/apps/site/e2e/features/groups.spec.ts
+++ b/apps/site/e2e/features/groups.spec.ts
@@ -100,9 +100,9 @@ test.describe('A new user', () => {
   }) => {
     await page.goto(group.url)
     await expect(
-      page.getByText(
-        `${group.admin.firstName} vous a invité à rejoindre le groupe`
-      )
+      page.getByRole('heading', {
+        name: `${group.admin.firstName} vous a invité à rejoindre le groupe`,
+      })
     ).toBeInViewport()
   })
 

--- a/apps/site/e2e/features/locale-persistence.spec.ts
+++ b/apps/site/e2e/features/locale-persistence.spec.ts
@@ -5,11 +5,9 @@ test.describe('Locale persistence via cookie', () => {
     page,
   }) => {
     await page.goto('/fr')
-
     await expect(page.locator('html')).toHaveAttribute('lang', 'fr')
 
     await page.goto('/en')
-
     await expect(page).toHaveURL(/\/en/)
     await expect(page.locator('html')).toHaveAttribute('lang', 'en')
   })
@@ -18,12 +16,10 @@ test.describe('Locale persistence via cookie', () => {
     page,
   }) => {
     await page.goto('/en')
-
     await expect(page).toHaveURL(/\/en/)
     await expect(page.locator('html')).toHaveAttribute('lang', 'en')
 
     await page.goto('/fr')
-
     await expect(page.locator('html')).toHaveAttribute('lang', 'fr')
   })
 })

--- a/apps/site/e2e/features/mode-scolaire.spec.ts
+++ b/apps/site/e2e/features/mode-scolaire.spec.ts
@@ -72,6 +72,8 @@ test.describe('When a user completes the test via the scolaire poll invite link'
     await page.goto(scolairePoll.inviteLink)
     await expect(page).toHaveURL(/\/simulateur\/campagne\//)
     await expect(page.getByTestId('skip-tutorial-button')).toBeHidden()
-    await expect(page.locator(`a[href="${scolairePoll.url}"]`)).toBeVisible()
+    await expect(
+      page.locator(`a[href="${scolairePoll.url}"]`).filter({ visible: true })
+    ).toBeVisible()
   })
 })

--- a/apps/site/e2e/features/organisation-admin.spec.ts
+++ b/apps/site/e2e/features/organisation-admin.spec.ts
@@ -29,7 +29,10 @@ test.describe('The dashboard', () => {
 
   test('welcomes the admin', async ({ page, organisation }) => {
     await expect(
-      page.getByText(`Bienvenue ${organisation.admin.fullName}`)
+      page.getByRole('heading', {
+        name: `Bienvenue ${organisation.admin.fullName}`,
+        level: 1,
+      })
     ).toBeVisible()
   })
 
@@ -38,12 +41,14 @@ test.describe('The dashboard', () => {
     organisation,
   }) => {
     await expect(
-      page.getByRole('link', { name: organisation.name })
+      page.getByRole('link', { name: organisation.name, exact: true })
     ).toBeVisible()
   })
 
   test('lists the created poll', async ({ page, poll }) => {
-    await expect(page.getByText(poll.name)).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: poll.name, level: 3, exact: true })
+    ).toBeVisible()
     await page.getByTestId('poll-card-see-details-button').first().click()
     await expect(page).toHaveURL(poll.url)
   })

--- a/apps/site/e2e/features/organisation-admin.spec.ts
+++ b/apps/site/e2e/features/organisation-admin.spec.ts
@@ -10,7 +10,7 @@ test('can access the organisation dashboard from the user account', async ({
 }) => {
   await userSpace.goto()
   await page.getByTestId('my-groups-tab').click()
-  await page.getByText(organisation.name).click()
+  await page.getByRole('link', { name: organisation.name }).click()
   await expect(page).toHaveURL(organisation.url)
 })
 
@@ -37,7 +37,9 @@ test.describe('The dashboard', () => {
     page,
     organisation,
   }) => {
-    await expect(page.getByText(organisation.name)).toBeVisible()
+    await expect(
+      page.getByRole('link', { name: organisation.name })
+    ).toBeVisible()
   })
 
   test('lists the created poll', async ({ page, poll }) => {

--- a/apps/site/e2e/features/polls.spec.ts
+++ b/apps/site/e2e/features/polls.spec.ts
@@ -17,7 +17,9 @@ test.describe('A poll admin', () => {
     poll,
   }) => {
     await page.goto(organisation.url)
-    await expect(page.getByRole('heading', { name: poll.name })).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: poll.name, level: 3, exact: true })
+    ).toBeVisible()
     await page.getByTestId('poll-card-see-details-button').first().click()
     await expect(page).toHaveURL(poll.url)
   })
@@ -37,7 +39,9 @@ test.describe('A poll admin', () => {
       await page.getByText('Supprimer cette campagne').click()
       await page.getByText('Confirmer').click()
       await expect(page).toHaveURL(organisation.url)
-      await expect(page.getByText(newPoll.name)).toBeHidden()
+      await expect(
+        page.getByRole('heading', { name: newPoll.name, level: 3, exact: true })
+      ).toBeHidden()
     })
   })
 })
@@ -48,7 +52,9 @@ test.describe('The poll dashboard page, when accessed by an admin', () => {
   })
 
   test('displays poll name', async ({ poll, page }) => {
-    await expect(page.locator('h1')).toHaveText(poll.name)
+    await expect(
+      page.getByRole('heading', { name: poll.name, level: 1, exact: true })
+    ).toBeVisible()
   })
 
   test('has an invite link that can be copied with good utm', async ({

--- a/apps/site/e2e/features/polls.spec.ts
+++ b/apps/site/e2e/features/polls.spec.ts
@@ -17,7 +17,7 @@ test.describe('A poll admin', () => {
     poll,
   }) => {
     await page.goto(organisation.url)
-    await expect(page.getByText(poll.name)).toBeVisible()
+    await expect(page.getByRole('heading', { name: poll.name })).toBeVisible()
     await page.getByTestId('poll-card-see-details-button').first().click()
     await expect(page).toHaveURL(poll.url)
   })
@@ -165,6 +165,8 @@ test.describe('A user with a completed test that joined a poll', () => {
     await page.goto(poll.inviteLink)
     await expect(page).toHaveURL(/\/simulateur\/campagne\//)
     await expect(page.getByTestId('skip-tutorial-button')).toBeHidden()
-    await expect(page.locator(`a[href="${poll.url}"]`)).toBeVisible()
+    await expect(
+      page.locator(`a[href="${poll.url}"]`).filter({ visible: true })
+    ).toBeVisible()
   })
 })

--- a/apps/site/e2e/features/resultat.spec.ts
+++ b/apps/site/e2e/features/resultat.spec.ts
@@ -83,6 +83,8 @@ test.describe('Given an authenticated user that completed the test twice with di
     await expect(tendencyIndicator).toBeVisible()
 
     // Verify it shows the correct text (increase or decrease)
-    await expect(page.getByText(/votre dernier résultat/)).toBeVisible()
+    await expect(
+      page.getByText(/votre dernier résultat/).filter({ visible: true })
+    ).toBeVisible()
   })
 })

--- a/apps/site/e2e/features/user-account.spec.ts
+++ b/apps/site/e2e/features/user-account.spec.ts
@@ -2,7 +2,11 @@ import { START_SIMULATION_PATH } from '@/constants/urls/paths'
 import { faker } from '@faker-js/faker'
 import { expect, test } from '../fixtures'
 import { UserMailbox } from '../helpers/user-mailbox'
-import { GROUP_ADMIN_STATE, NEW_VISITOR_STATE, USER_ACCOUNT_STATE } from '../state'
+import {
+  GROUP_ADMIN_STATE,
+  NEW_VISITOR_STATE,
+  USER_ACCOUNT_STATE,
+} from '../state'
 
 test.use({ storageState: USER_ACCOUNT_STATE })
 
@@ -98,7 +102,6 @@ test.describe('Simulation deletion', () => {
   }) => {
     await page.goto(START_SIMULATION_PATH)
     await ngcTest.skipAllQuestions()
-    await page.waitForURL('/fin')
 
     await page.goto('/mon-espace')
     await expect(page.getByTestId('results-list-title')).toBeVisible()

--- a/apps/site/e2e/fixtures/feature-flags.ts
+++ b/apps/site/e2e/fixtures/feature-flags.ts
@@ -2,6 +2,7 @@ import { test as base, type Browser, type Page } from '@playwright/test'
 
 import { FF_COOKIE_NAME } from '@/services/feature-flags/constants'
 import type { DefaultFlagValues } from '@/services/feature-flags/flags'
+import { patchGetByTestId } from './visible-testid'
 
 const DOMAIN = new URL(process.env.NEXT_PUBLIC_SITE_URL!).hostname
 
@@ -44,6 +45,7 @@ export class FeatureFlags {
 
 export async function createPage(browser: Browser): Promise<Page> {
   const page = await browser.newPage()
+  patchGetByTestId(page)
   const ff = new FeatureFlags(page)
   await ff.set({ ...DEFAULT_FLAGS })
   return page

--- a/apps/site/e2e/fixtures/groups.ts
+++ b/apps/site/e2e/fixtures/groups.ts
@@ -75,7 +75,8 @@ export class Group {
   }
 
   async leave(page: Page) {
-    await page.getByTestId('button-leave-group').click()
+    await page.getByRole('button', { name: 'Quitter le groupe' }).click()
+    await expect(page.getByTestId('button-confirm-leave-group')).toBeVisible()
     await page.getByTestId('button-confirm-leave-group').click()
   }
 
@@ -91,7 +92,7 @@ export class Group {
   async goFromGroupTabs(page: Page) {
     await page.getByTestId('my-groups-tab').click()
     await page.waitForTimeout(500)
-    await page.getByText(this.name).click()
+    await page.getByText(this.name).filter({ visible: true }).click()
   }
 
   async saveInContext() {

--- a/apps/site/e2e/fixtures/index.ts
+++ b/apps/site/e2e/fixtures/index.ts
@@ -8,6 +8,7 @@ import { test as pollTest } from '../fixtures/polls'
 import { test as scolairePollTest } from '../fixtures/scolaire-poll'
 
 import { test as userAccountTest } from '../fixtures/user-account'
+import { test as visibleTestIdTest } from '../fixtures/visible-testid'
 
 export const test = mergeTests(
   groupTest,
@@ -17,6 +18,8 @@ export const test = mergeTests(
   organisationTest,
   userAccountTest,
   pollTest,
-  scolairePollTest
+  scolairePollTest,
+  visibleTestIdTest
 )
 export { expect } from '@playwright/test'
+export type { Locator, Page } from '@playwright/test'

--- a/apps/site/e2e/fixtures/polls.ts
+++ b/apps/site/e2e/fixtures/polls.ts
@@ -49,6 +49,9 @@ export class Poll {
   async create(mode: SimulationMode = 'standard') {
     // Step 1: Fill poll name and go to step 2
     await expect(this.page).toHaveURL(this.createUrl)
+    // Clear first to avoid any default value from a previous poll's draft
+    // (the input is pre-filled from a previous draft via react-hook-form)
+    await this.page.getByTestId('poll-name-input').clear()
     await this.page.getByTestId('poll-name-input').fill(this.name)
     await this.page.getByTestId('poll-form-name-button').click()
 

--- a/apps/site/e2e/fixtures/user.ts
+++ b/apps/site/e2e/fixtures/user.ts
@@ -54,7 +54,9 @@ export class User {
   }
 
   async fillEmailAndCompleteVerification() {
-    const emailInput = this.page.getByTestId('verification-code-email-input')
+    const emailInput = this.page
+      .getByTestId('verification-code-email-input')
+      .locator('visible=true')
     await emailInput.scrollIntoViewIfNeeded()
     await emailInput.fill(this.email)
     await this.page.waitForTimeout(500)

--- a/apps/site/e2e/fixtures/user.ts
+++ b/apps/site/e2e/fixtures/user.ts
@@ -54,9 +54,7 @@ export class User {
   }
 
   async fillEmailAndCompleteVerification() {
-    const emailInput = this.page
-      .getByTestId('verification-code-email-input')
-      .locator('visible=true')
+    const emailInput = this.page.getByTestId('verification-code-email-input')
     await emailInput.scrollIntoViewIfNeeded()
     await emailInput.fill(this.email)
     await this.page.waitForTimeout(500)

--- a/apps/site/e2e/fixtures/visible-testid.ts
+++ b/apps/site/e2e/fixtures/visible-testid.ts
@@ -2,18 +2,27 @@
  * Monkey-patches `page.getByTestId` to always filter by `{ visible: true }`.
  *
  * With `cacheComponents`, React <Activity> keeps previous routes in the DOM
- * (hidden via `display: none`). Playwright locators match all elements
- * regardless of visibility, including those from previous routes.
+ * (hidden via `display: none`). Playwright locators would otherwise match
+ * those hidden copies and fail strict-mode.
  *
- * @see https://github.com/vercel/next.js/issues/86577
+ * Call this once per page (the fixture below does it for `page` from the
+ * test fixture; `createPage` in feature-flags.ts does it for pages created
+ * via `browser.newPage()`).
  */
+import type { Page } from '@playwright/test'
+
+export function patchGetByTestId(page: Page) {
+  const original = page.getByTestId.bind(page)
+  ;(page as unknown as { getByTestId: typeof page.getByTestId }).getByTestId =
+    ((id: string | RegExp) =>
+      original(id).filter({ visible: true })) as typeof page.getByTestId
+}
+
 import { test as base } from '@playwright/test'
 
 export const test = base.extend({
   page: async ({ page }, use) => {
-    const original = page.getByTestId.bind(page)
-    page.getByTestId = ((id: string | RegExp) =>
-      original(id).filter({ visible: true })) as typeof page.getByTestId
+    patchGetByTestId(page)
     await use(page)
   },
 })

--- a/apps/site/e2e/fixtures/visible-testid.ts
+++ b/apps/site/e2e/fixtures/visible-testid.ts
@@ -1,0 +1,19 @@
+/**
+ * Monkey-patches `page.getByTestId` to always filter by `{ visible: true }`.
+ *
+ * With `cacheComponents`, React <Activity> keeps previous routes in the DOM
+ * (hidden via `display: none`). Playwright locators match all elements
+ * regardless of visibility, including those from previous routes.
+ *
+ * @see https://github.com/vercel/next.js/issues/86577
+ */
+import { test as base } from '@playwright/test'
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    const original = page.getByTestId.bind(page)
+    page.getByTestId = ((id: string | RegExp) =>
+      original(id).filter({ visible: true })) as typeof page.getByTestId
+    await use(page)
+  },
+})

--- a/apps/site/e2e/pages/documentation.spec.ts
+++ b/apps/site/e2e/pages/documentation.spec.ts
@@ -6,7 +6,9 @@ export const DOCUMENTATION_LAUNCH_BUTTON = 'documentation-launch-button'
 test('/documentation', async ({ page }) => {
   await page.goto('/documentation')
 
-  expect(page.locator('h1').getByText('Documentation')).toBeDefined()
+  expect(
+    page.getByRole('heading', { level: 1, name: 'Documentation' })
+  ).toBeDefined()
 })
 
 test.describe('/documentation/bilan', () => {

--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -58,12 +58,12 @@ const nextConfig = withMDX({
       },
     },
   },
+  cacheComponents: true,
   experimental: {
     optimizePackageImports: ['@incubateur-ademe/nosgestesclimat'],
     webpackBuildWorker: true,
     authInterrupts: true,
     mdxRs: true,
-    useCache: true,
   },
 
   webpack(config) {

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -65,7 +65,7 @@
     "is-mobile": "^5.0.0",
     "jszip": "^3.10.1",
     "markdown-to-jsx": "^7.7.17",
-    "next": "16.1.5",
+    "next": "16.2.10",
     "next-i18n-router": "^5.5.6",
     "pino": "^10.3.1",
     "posthog-js": "^1.406.1",

--- a/apps/site/src/app/[locale]/(server)/layout.tsx
+++ b/apps/site/src/app/[locale]/(server)/layout.tsx
@@ -4,6 +4,7 @@ import HeaderServer from '@/components/layout/HeaderServer'
 import SkipToMainContentLink from '@/design-system/accessibility/SkipToMainContentLink'
 import Banner from '@/design-system/cms/Banner'
 import type { Locale } from '@/i18nConfig'
+import { Suspense } from 'react'
 
 export default async function LargeLayout({
   children,
@@ -13,7 +14,9 @@ export default async function LargeLayout({
   return (
     <>
       <SkipToMainContentLink />
-      <Banner locale={locale as Locale} />
+      <Suspense fallback={null}>
+        <Banner locale={locale as Locale} />
+      </Suspense>
       <HeaderServer locale={locale} />
       {children}
       <GoogleTagScript />

--- a/apps/site/src/app/[locale]/layout.tsx
+++ b/apps/site/src/app/[locale]/layout.tsx
@@ -8,9 +8,17 @@ import Script from 'next/script'
 import { Suspense } from 'react'
 
 import DefaultProvider from '@/publicodes-state/providers/DefaultProvider'
+import i18nConfig from '@/i18nConfig'
 import { BODY_ID } from './_components/mainLayoutProviders/IframeOptionsContext'
 import './globals.css'
 import { marianne } from './marianne'
+
+
+export function generateStaticParams() {
+  return i18nConfig.locales.map((locale: string) => ({
+    locale,
+  }))
+}
 
 export default async function RootLayout({
   children,
@@ -37,7 +45,7 @@ export default async function RootLayout({
         <meta name="theme-color" content="#4949ba" />
 
         <MatomoScript__deprecated />
-        <Suspense>
+        <Suspense fallback={null}>
           <Trackers locale={locale} />
         </Suspense>
 

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -7,7 +7,7 @@ import Trans from '@/components/translation/trans/TransServer'
 import LandingPage from '@/design-system/layout/LandingPage'
 import { t } from '@/helpers/metadata/fakeMetadataT'
 import { getCommonMetadata } from '@/helpers/metadata/getCommonMetadata'
-import i18nConfig, { type Locale } from '@/i18nConfig'
+import { type Locale } from '@/i18nConfig'
 import { getUserSession } from '@/services/auth/get-user-session'
 import Partners from '../../components/landing-pages/Partners'
 import CollectivelyCommit from './_components/CollectivelyCommit'
@@ -32,12 +32,6 @@ export const generateMetadata = getCommonMetadata({
     canonical: '',
   },
 })
-
-export function generateStaticParams() {
-  return i18nConfig.locales.map((locale: string) => ({
-    locale,
-  }))
-}
 
 export default async function Homepage({ params }: PageProps<'/[locale]'>) {
   const locale = (await params).locale as Locale

--- a/apps/site/src/app/not-found.tsx
+++ b/apps/site/src/app/not-found.tsx
@@ -3,6 +3,7 @@ import { noIndexObject } from '@/constants/metadata'
 import { getMetadataObject } from '@/helpers/metadata/getMetadataObject'
 import i18nConfig from '@/i18nConfig'
 import './[locale]/globals.css'
+import { Suspense } from 'react'
 import { marianne } from './[locale]/marianne'
 
 export function generateMetadata() {
@@ -19,7 +20,9 @@ export default function NotFound() {
   return (
     <html lang="fr">
       <body className={`${marianne.className} text-default bg-white`}>
-        <Route404 locale={i18nConfig.defaultLocale} />
+        <Suspense fallback={null}>
+          <Route404 locale={i18nConfig.defaultLocale} />
+        </Suspense>
       </body>
     </html>
   )

--- a/apps/site/src/components/layout/404.tsx
+++ b/apps/site/src/components/layout/404.tsx
@@ -3,16 +3,21 @@ import Main from '@/design-system/layout/Main'
 import { getServerTranslation } from '@/helpers/getServerTranslation'
 import type { Locale } from '@/i18nConfig'
 import Image from 'next/image'
+import { cacheLife } from 'next/cache'
 import Wave from 'react-wavify'
 import Trans from '../translation/trans/TransServer'
-import HeaderServer from './HeaderServer'
+import LogoHeader from './headerServer/LogoHeader'
 
 export default async function Route404({ locale }: { locale: Locale }) {
+  'use cache'
+  cacheLife('days')
   const { t } = await getServerTranslation({ locale })
 
   return (
     <>
-      <HeaderServer locale={locale} />
+      <header className="h-20 items-center bg-white shadow-xs">
+        <LogoHeader />
+      </header>
 
       <Main>
         <div className="relative h-svh" data-testid="404">

--- a/apps/site/src/components/layout/ClientLayout.tsx
+++ b/apps/site/src/components/layout/ClientLayout.tsx
@@ -39,7 +39,9 @@ export const ClientLayout = ({
           </Suspense>
           <SkipToMainContentLink skipLinksDisplayed={skipLinksDisplayed} />
 
-          <Banner locale={locale as Locale} />
+          <Suspense fallback={null}>
+            <Banner locale={locale as Locale} />
+          </Suspense>
           {children}
           <GoogleTagScript />
           <GoogleTagIframe />

--- a/apps/site/src/components/layout/HeaderServer.tsx
+++ b/apps/site/src/components/layout/HeaderServer.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from 'react'
 import { twMerge } from 'tailwind-merge'
-import LogoLinkServer from '../misc/LogoLinkServer'
 import HideInIframe from './HideInIframe'
 import MySpaceButton from './headerServer/MySpaceButton'
+import LogoHeader from './headerServer/LogoHeader'
 
 interface Props {
   isSticky?: boolean
@@ -17,22 +17,16 @@ export default function HeaderServer({ isSticky = true, locale }: Props) {
         'h-20 items-center bg-white shadow-xs',
         isSticky ? 'sticky top-0 z-300' : ''
       )}>
-      <div className="absolute top-0 right-0 bottom-0 left-0 h-20 w-full items-center border-b border-gray-200 bg-white shadow-xs md:flex">
-        <div className="mx-auto flex h-full w-full max-w-5xl items-center justify-between gap-6 px-4 md:px-0">
-          <div className="flex origin-left items-center justify-center">
-            <LogoLinkServer />
-          </div>
-
-          <div className="flex h-full items-center">
-            <Suspense>
-              {/*Suspense for enabling partial prerendering */}
-              <HideInIframe hideIfNotFrenchRegion>
-                <MySpaceButton locale={locale} />
-              </HideInIframe>
-            </Suspense>
-          </div>
-        </div>
-      </div>
+      <LogoHeader
+        rightContent={
+          <Suspense fallback={null}>
+            {/*Suspense for enabling partial prerendering */}
+            <HideInIframe hideIfNotFrenchRegion>
+              <MySpaceButton locale={locale} />
+            </HideInIframe>
+          </Suspense>
+        }
+      />
     </header>
   )
 }

--- a/apps/site/src/components/layout/headerServer/LogoHeader.tsx
+++ b/apps/site/src/components/layout/headerServer/LogoHeader.tsx
@@ -1,0 +1,20 @@
+import LogoLinkServer from '../../misc/LogoLinkServer'
+
+interface Props {
+  rightContent?: React.ReactNode
+}
+
+export default function LogoHeader({ rightContent }: Props) {
+  return (
+    <div className="absolute top-0 right-0 bottom-0 left-0 h-20 w-full items-center border-b border-gray-200 bg-white shadow-xs md:flex">
+      <div className="mx-auto flex h-full w-full max-w-5xl items-center justify-between gap-6 px-4 md:px-0">
+        <div className="flex origin-left items-center justify-center">
+          <LogoLinkServer />
+        </div>
+        {rightContent && (
+          <div className="flex h-full items-center">{rightContent}</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/site/src/i18nConfig.ts
+++ b/apps/site/src/i18nConfig.ts
@@ -11,7 +11,6 @@ export type Locale = 'fr' | 'en'
 const i18nConfig: Config & { locales: Locale[]; defaultLocale: Locale } = {
   locales: [LOCALE_FR_KEY, LOCALE_EN_KEY],
   defaultLocale: LOCALE_FR_KEY,
-  serverSetCookie: 'if-empty' as const,
   cookieOptions: {
     sameSite: 'none' as const,
     path: '/',

--- a/apps/site/src/i18nConfig.ts
+++ b/apps/site/src/i18nConfig.ts
@@ -11,6 +11,7 @@ export type Locale = 'fr' | 'en'
 const i18nConfig: Config & { locales: Locale[]; defaultLocale: Locale } = {
   locales: [LOCALE_FR_KEY, LOCALE_EN_KEY],
   defaultLocale: LOCALE_FR_KEY,
+  serverSetCookie: 'if-empty' as const,
   cookieOptions: {
     sameSite: 'none' as const,
     path: '/',

--- a/apps/site/src/services/actions/get-action-alternate-locales.ts
+++ b/apps/site/src/services/actions/get-action-alternate-locales.ts
@@ -1,4 +1,10 @@
 import { getActionAlternateLocales as _getActionAlternateLocales } from '@nosgestesclimat/core/features/actions/services/get-action-alternate-locales.service'
-import { cache } from 'react'
+import { cacheLife } from 'next/cache'
 
-export const getActionAlternateLocales = cache(_getActionAlternateLocales)
+export async function getActionAlternateLocales(
+  ...args: Parameters<typeof _getActionAlternateLocales>
+) {
+  'use cache'
+  cacheLife('minutes')
+  return await _getActionAlternateLocales(...args)
+}

--- a/apps/site/src/services/actions/get-personalized-action-details.ts
+++ b/apps/site/src/services/actions/get-personalized-action-details.ts
@@ -1,4 +1,10 @@
 import { getPersonalizedActionDetails as _getPersonalizedActionDetails } from '@nosgestesclimat/core/features/actions/services/get-personalized-action-details.service'
-import { cache } from 'react'
+import { cacheLife } from 'next/cache'
 
-export const getPersonalizedActionDetails = cache(_getPersonalizedActionDetails)
+export async function getPersonalizedActionDetails(
+  ...args: Parameters<typeof _getPersonalizedActionDetails>
+) {
+  'use cache'
+  cacheLife('minutes')
+  return await _getPersonalizedActionDetails(...args)
+}

--- a/apps/site/src/services/actions/get-personalized-actions-catalogue.ts
+++ b/apps/site/src/services/actions/get-personalized-actions-catalogue.ts
@@ -1,6 +1,10 @@
 import { getPersonalizedActionsCatalogue as _getPersonalizedActionsCatalogue } from '@nosgestesclimat/core/features/actions/services/get-personalized-actions-catalogue.service'
-import { cache } from 'react'
+import { cacheLife } from 'next/cache'
 
-export const getPersonalizedActionsCatalogue = cache(
-  _getPersonalizedActionsCatalogue
-)
+export async function getPersonalizedActionsCatalogue(
+  ...args: Parameters<typeof _getPersonalizedActionsCatalogue>
+) {
+  'use cache'
+  cacheLife('minutes')
+  return await _getPersonalizedActionsCatalogue(...args)
+}

--- a/apps/site/src/services/actions/get-public-actions-catalogue.ts
+++ b/apps/site/src/services/actions/get-public-actions-catalogue.ts
@@ -1,4 +1,10 @@
 import { getPublicActionsCatalogue as _getPublicActionsCatalogue } from '@nosgestesclimat/core/features/actions/services/get-public-actions-catalogue.service'
-import { cache } from 'react'
+import { cacheLife } from 'next/cache'
 
-export const getPublicActionsCatalogue = cache(_getPublicActionsCatalogue)
+export async function getPublicActionsCatalogue(
+  ...args: Parameters<typeof _getPublicActionsCatalogue>
+) {
+  'use cache'
+  cacheLife('minutes')
+  return await _getPublicActionsCatalogue(...args)
+}

--- a/apps/site/src/services/cms/fetchBanner.ts
+++ b/apps/site/src/services/cms/fetchBanner.ts
@@ -3,8 +3,11 @@ import { cmsClient } from '@/adapters/cmsClient'
 import { type Locale } from '@/i18nConfig'
 import { captureException } from '@sentry/nextjs'
 import dayjs from 'dayjs'
+import { cacheLife } from 'next/cache'
 
 export async function fetchBanner(locale: Locale): Promise<BannerType | null> {
+  'use cache'
+  cacheLife('hours')
   try {
     const currentDate = dayjs()
 

--- a/infra/nginx/cloud-init.tpl.yaml
+++ b/infra/nginx/cloud-init.tpl.yaml
@@ -22,6 +22,16 @@ write_files:
       REPO=__REPO__
       TEMPLATE_REF=__TEMPLATE_REF__
 
+  - path: /etc/systemd/system/nginx.service.d/override.conf
+    permissions: '0644'
+    content: |
+      [Service]
+      Restart=on-failure
+      RestartSec=10s
+      TimeoutStartSec=60s
+      StartLimitIntervalSec=3600
+      StartLimitBurst=360
+
 runcmd:
   - mkdir -p /var/cache/nginx /var/lib/nginx-config
   - chown -R www-data:www-data /var/cache/nginx

--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -10,8 +10,11 @@ map $cookie_ngc_session $ngc_is_auth {
     default  1;
 }
 
+resolver 1.1.1.1 8.8.8.8 valid=30s;
+
 upstream scalingo {
-    server ${UPSTREAM}:443;
+    zone scalingo 64k;
+    server ${UPSTREAM}:443 resolve;
     keepalive 64;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 7.8.0
       '@prisma/client':
         specifier: ^7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
       '@publicodes/tools':
         specifier: ^1.8.0
         version: 1.8.0(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
@@ -103,13 +103,13 @@ importers:
         version: 10.48.0
       '@ts-rest/core':
         specifier: ^3.53.0-rc.1
-        version: 3.53.0-rc.1(@types/node@24.12.2)
+        version: 3.53.0-rc.1(@types/node@18.19.130)
       '@ts-rest/express':
         specifier: ^3.53.0-rc.1
-        version: 3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.12.2))(express@4.22.1)
+        version: 3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@18.19.130))(express@4.22.1)
       '@ts-rest/open-api':
         specifier: ^3.53.0-rc.1
-        version: 3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.12.2))(zod@4.3.6)
+        version: 3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@18.19.130))(zod@4.3.6)
       axios:
         specifier: ^1.14.0
         version: 1.14.0
@@ -230,10 +230,10 @@ importers:
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
       msw:
         specifier: ^2.12.14
-        version: 2.12.14(@types/node@24.12.2)(typescript@5.9.3)
+        version: 2.12.14(@types/node@18.19.130)(typescript@5.9.3)
       pglite-prisma-adapter:
         specifier: ^0.6.1
-        version: 0.6.1(@electric-sql/pglite@0.3.16)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))
+        version: 0.6.1(@electric-sql/pglite@0.3.16)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3))
       redis-mock:
         specifier: ^0.56.3
         version: 0.56.3
@@ -245,7 +245,7 @@ importers:
         version: 7.2.2
       vitest:
         specifier: ^4.1.2
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@24.12.2)(typescript@5.9.3))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@18.19.130)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/site:
     dependencies:
@@ -266,7 +266,7 @@ importers:
         version: 1.8.0(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
       '@sentry/nextjs':
         specifier: ^10.46.0
-        version: 10.46.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(esbuild@0.27.7))
+        version: 10.46.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(esbuild@0.27.7))
       '@splidejs/react-splide':
         specifier: ^0.7.12
         version: 0.7.12
@@ -316,11 +316,11 @@ importers:
         specifier: ^7.7.17
         version: 7.7.17(react@19.2.4)
       next:
-        specifier: 16.1.5
-        version: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.10
+        version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-i18n-router:
         specifier: ^5.5.6
-        version: 5.5.6(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 5.5.6(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -414,7 +414,7 @@ importers:
         version: 1.61.0
       '@storybook/addon-docs':
         specifier: ^10.3.3
-        version: 10.3.3(@types/react@19.2.2)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
+        version: 10.3.3(@types/react@19.2.2)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
       '@storybook/addon-onboarding':
         specifier: ^10.3.3
         version: 10.3.3(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -423,10 +423,10 @@ importers:
         version: 10.3.3(@vitest/browser@4.1.4)(@vitest/runner@4.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.4)
       '@storybook/nextjs':
         specifier: ^10.3.3
-        version: 10.3.3(@types/webpack@5.28.5(esbuild@0.27.7))(esbuild@0.27.7)(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.7))
+        version: 10.3.3(@types/webpack@5.28.5(esbuild@0.27.7))(esbuild@0.27.7)(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.7))
       '@storybook/nextjs-vite':
         specifier: ^10.3.3
-        version: 10.3.3(@babel/core@7.29.0)(esbuild@0.27.7)(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
+        version: 10.3.3(@babel/core@7.29.0)(esbuild@0.27.7)(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -456,10 +456,10 @@ importers:
         version: 5.28.5(esbuild@0.27.7)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.2.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/browser':
         specifier: ^4.1.2
-        version: 4.1.4(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+        version: 4.1.4(msw@2.12.14(@types/node@24.12.2)(typescript@5.9.3))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: ^4.1.2
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
@@ -492,10 +492,10 @@ importers:
         version: 2.2.2
       msw:
         specifier: ^2.12.14
-        version: 2.12.14(@types/node@18.19.130)(typescript@5.9.3)
+        version: 2.12.14(@types/node@24.12.2)(typescript@5.9.3)
       msw-storybook-addon:
         specifier: ^2.0.5
-        version: 2.0.5(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))
+        version: 2.0.5(msw@2.12.14(@types/node@24.12.2)(typescript@5.9.3))
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
@@ -516,10 +516,10 @@ importers:
         version: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       vite:
         specifier: ^6.0.0
-        version: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@18.19.130)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@24.12.2)(typescript@5.9.3))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       yaml-loader:
         specifier: ^0.9.0
         version: 0.9.0
@@ -2199,8 +2199,8 @@ packages:
   '@next/env@16.0.0':
     resolution: {integrity: sha512-s5j2iFGp38QsG1LWRQaE2iUY3h1jc014/melHFfLdrsMJPqxqDQwWNwyQTcNoUSGZlCVZuM7t7JDMmSyRilsnA==}
 
-  '@next/env@16.1.5':
-    resolution: {integrity: sha512-CRSCPJiSZoi4Pn69RYBDI9R7YK2g59vLexPQFXY0eyw+ILevIenCywzg+DqmlBik9zszEnw2HLFOUlLAcJbL7g==}
+  '@next/env@16.2.10':
+    resolution: {integrity: sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==}
 
   '@next/eslint-plugin-next@16.2.3':
     resolution: {integrity: sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==}
@@ -2216,54 +2216,54 @@ packages:
       '@mdx-js/react':
         optional: true
 
-  '@next/swc-darwin-arm64@16.1.5':
-    resolution: {integrity: sha512-eK7Wdm3Hjy/SCL7TevlH0C9chrpeOYWx2iR7guJDaz4zEQKWcS1IMVfMb9UKBFMg1XgzcPTYPIp1Vcpukkjg6Q==}
+  '@next/swc-darwin-arm64@16.2.10':
+    resolution: {integrity: sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.5':
-    resolution: {integrity: sha512-foQscSHD1dCuxBmGkbIr6ScAUF6pRoDZP6czajyvmXPAOFNnQUJu2Os1SGELODjKp/ULa4fulnBWoHV3XdPLfA==}
+  '@next/swc-darwin-x64@16.2.10':
+    resolution: {integrity: sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.1.5':
-    resolution: {integrity: sha512-qNIb42o3C02ccIeSeKjacF3HXotGsxh/FMk/rSRmCzOVMtoWH88odn2uZqF8RLsSUWHcAqTgYmPD3pZ03L9ZAA==}
+  '@next/swc-linux-arm64-gnu@16.2.10':
+    resolution: {integrity: sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.1.5':
-    resolution: {integrity: sha512-U+kBxGUY1xMAzDTXmuVMfhaWUZQAwzRaHJ/I6ihtR5SbTVUEaDRiEU9YMjy1obBWpdOBuk1bcm+tsmifYSygfw==}
+  '@next/swc-linux-arm64-musl@16.2.10':
+    resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.1.5':
-    resolution: {integrity: sha512-gq2UtoCpN7Ke/7tKaU7i/1L7eFLfhMbXjNghSv0MVGF1dmuoaPeEVDvkDuO/9LVa44h5gqpWeJ4mRRznjDv7LA==}
+  '@next/swc-linux-x64-gnu@16.2.10':
+    resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.1.5':
-    resolution: {integrity: sha512-bQWSE729PbXT6mMklWLf8dotislPle2L70E9q6iwETYEOt092GDn0c+TTNj26AjmeceSsC4ndyGsK5nKqHYXjQ==}
+  '@next/swc-linux-x64-musl@16.2.10':
+    resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.1.5':
-    resolution: {integrity: sha512-LZli0anutkIllMtTAWZlDqdfvjWX/ch8AFK5WgkNTvaqwlouiD1oHM+WW8RXMiL0+vAkAJyAGEzPPjO+hnrSNQ==}
+  '@next/swc-win32-arm64-msvc@16.2.10':
+    resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.5':
-    resolution: {integrity: sha512-7is37HJTNQGhjPpQbkKjKEboHYQnCgpVt/4rBrrln0D9nderNxZ8ZWs8w1fAtzUx7wEyYjQ+/13myFgFj6K2Ng==}
+  '@next/swc-win32-x64-msvc@16.2.10':
+    resolution: {integrity: sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -7630,8 +7630,8 @@ packages:
     peerDependencies:
       next: ^13 || ^14 || ^15 || ^16
 
-  next@16.1.5:
-    resolution: {integrity: sha512-f+wE+NSbiQgh3DSAlTaw2FwY5yGdVViAtp8TotNQj4kk4Q8Bh1sC/aL9aH+Rg1YAVn18OYXsRDT7U/079jgP7w==}
+  next@16.2.10:
+    resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -11756,7 +11756,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -11854,11 +11854,11 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -11960,7 +11960,7 @@ snapshots:
 
   '@next/env@16.0.0': {}
 
-  '@next/env@16.1.5': {}
+  '@next/env@16.2.10': {}
 
   '@next/eslint-plugin-next@16.2.3':
     dependencies:
@@ -11973,28 +11973,28 @@ snapshots:
       '@mdx-js/loader': 3.1.1(webpack@5.105.4(esbuild@0.27.7))
       '@mdx-js/react': 3.1.1(@types/react@19.2.2)(react@19.2.4)
 
-  '@next/swc-darwin-arm64@16.1.5':
+  '@next/swc-darwin-arm64@16.2.10':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.5':
+  '@next/swc-darwin-x64@16.2.10':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.5':
+  '@next/swc-linux-arm64-gnu@16.2.10':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.5':
+  '@next/swc-linux-arm64-musl@16.2.10':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.5':
+  '@next/swc-linux-x64-gnu@16.2.10':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.5':
+  '@next/swc-linux-x64-musl@16.2.10':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.5':
+  '@next/swc-win32-arm64-msvc@16.2.10':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.5':
+  '@next/swc-win32-x64-msvc@16.2.10':
     optional: true
 
   '@noble/hashes@1.8.0': {}
@@ -12706,6 +12706,13 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.8.0': {}
 
+  '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@prisma/client-runtime-utils': 7.8.0
+    optionalDependencies:
+      prisma: 7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      typescript: 5.9.3
+
   '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.8.0
@@ -12804,6 +12811,17 @@ snapshots:
       env-paths: 3.0.0
       proper-lockfile: 4.1.2
 
+  '@prisma/studio-core@0.27.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react': 19.2.2
+      chart.js: 4.5.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react-dom'
+    optional: true
+
   '@prisma/studio-core@0.27.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -12862,11 +12880,28 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.2)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.2
+    optional: true
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.2)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+    optional: true
 
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -12877,12 +12912,32 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.2
+    optional: true
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+    optional: true
 
   '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -12895,6 +12950,15 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.2)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.2)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.2
+    optional: true
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.2)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.2)(react@19.2.4)
@@ -12903,12 +12967,27 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.2)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.2
+    optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.2)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.2)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 19.2.2
+    optional: true
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.2)(react@19.2.4)':
     dependencies:
@@ -13106,7 +13185,7 @@ snapshots:
 
   '@sentry/core@10.48.0': {}
 
-  '@sentry/nextjs@10.46.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(esbuild@0.27.7))':
+  '@sentry/nextjs@10.46.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4(esbuild@0.27.7))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -13119,7 +13198,7 @@ snapshots:
       '@sentry/react': 10.46.0(react@19.2.4)
       '@sentry/vercel-edge': 10.46.0
       '@sentry/webpack-plugin': 5.1.1(webpack@5.105.4(esbuild@0.27.7))
-      next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.60.1
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -13624,10 +13703,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-docs@10.3.3(@types/react@19.2.2)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
+  '@storybook/addon-docs@10.3.3(@types/react@19.2.2)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.2)(react@19.2.4)
-      '@storybook/csf-plugin': 10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
+      '@storybook/csf-plugin': 10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.3.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -13651,19 +13730,19 @@ snapshots:
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     optionalDependencies:
-      '@vitest/browser': 4.1.4(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(msw@2.12.14(@types/node@24.12.2)(typescript@5.9.3))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
       '@vitest/runner': 4.1.4
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@18.19.130)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@24.12.2)(typescript@5.9.3))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
+  '@storybook/builder-vite@10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
+      '@storybook/csf-plugin': 10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -13701,14 +13780,14 @@ snapshots:
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
+  '@storybook/csf-plugin@10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
     dependencies:
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.60.1
-      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.27.7)
 
   '@storybook/global@5.0.0': {}
@@ -13718,18 +13797,18 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/nextjs-vite@10.3.3(@babel/core@7.29.0)(esbuild@0.27.7)(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
+  '@storybook/nextjs-vite@10.3.3(@babel/core@7.29.0)(esbuild@0.27.7)(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
     dependencies:
-      '@storybook/builder-vite': 10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
+      '@storybook/builder-vite': 10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
       '@storybook/react': 10.3.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
-      '@storybook/react-vite': 10.3.3(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
-      next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/react-vite': 10.3.3(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
+      next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
-      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-storybook-nextjs: 3.2.4(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-plugin-storybook-nextjs: 3.2.4(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13740,7 +13819,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/nextjs@10.3.3(@types/webpack@5.28.5(esbuild@0.27.7))(esbuild@0.27.7)(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.7))':
+  '@storybook/nextjs@10.3.3(@types/webpack@5.28.5(esbuild@0.27.7))(esbuild@0.27.7)(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.4(esbuild@0.27.7))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
@@ -13764,7 +13843,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.105.4(esbuild@0.27.7))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.4(esbuild@0.27.7))
       postcss: 8.5.6
       postcss-loader: 8.2.1(postcss@8.5.6)(typescript@5.9.3)(webpack@5.105.4(esbuild@0.27.7))
@@ -13843,11 +13922,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.3.3(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
+  '@storybook/react-vite@10.3.3(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
+      '@storybook/builder-vite': 10.3.3(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
       '@storybook/react': 10.3.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -13857,7 +13936,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -14005,19 +14084,19 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@ts-rest/core@3.53.0-rc.1(@types/node@24.12.2)':
+  '@ts-rest/core@3.53.0-rc.1(@types/node@18.19.130)':
     optionalDependencies:
-      '@types/node': 24.12.2
+      '@types/node': 18.19.130
 
-  '@ts-rest/express@3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.12.2))(express@4.22.1)':
+  '@ts-rest/express@3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@18.19.130))(express@4.22.1)':
     dependencies:
-      '@ts-rest/core': 3.53.0-rc.1(@types/node@24.12.2)
+      '@ts-rest/core': 3.53.0-rc.1(@types/node@18.19.130)
       express: 4.22.1
 
-  '@ts-rest/open-api@3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@24.12.2))(zod@4.3.6)':
+  '@ts-rest/open-api@3.53.0-rc.1(@ts-rest/core@3.53.0-rc.1(@types/node@18.19.130))(zod@4.3.6)':
     dependencies:
       '@anatine/zod-openapi': 1.14.2(openapi3-ts@2.0.2)(zod@4.3.6)
-      '@ts-rest/core': 3.53.0-rc.1(@types/node@24.12.2)
+      '@ts-rest/core': 3.53.0-rc.1(@types/node@18.19.130)
       openapi3-ts: 2.0.2
       zod: 4.3.6
 
@@ -14483,7 +14562,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@5.2.0(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitejs/plugin-react@5.2.0(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -14491,26 +14570,9 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
-
-  '@vitest/browser@4.1.4(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
-    dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.4(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/utils': 4.1.4
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@18.19.130)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.8.9)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
 
   '@vitest/browser@4.1.4(msw@2.12.14(@types/node@24.12.2)(typescript@5.9.3))(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
@@ -14528,7 +14590,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/coverage-v8@4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)':
     dependencies:
@@ -18326,10 +18387,10 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw-storybook-addon@2.0.5(msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3)):
+  msw-storybook-addon@2.0.5(msw@2.12.14(@types/node@24.12.2)(typescript@5.9.3)):
     dependencies:
       is-node-process: 1.2.0
-      msw: 2.12.14(@types/node@18.19.130)(typescript@5.9.3)
+      msw: 2.12.14(@types/node@24.12.2)(typescript@5.9.3)
 
   msw@2.12.14(@types/node@18.19.130)(typescript@5.9.3):
     dependencies:
@@ -18418,15 +18479,15 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-i18n-router@5.5.6(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  next-i18n-router@5.5.6(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       negotiator: 1.0.0
-      next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.1.5
+      '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.11
       caniuse-lite: 1.0.30001781
@@ -18435,14 +18496,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.5
-      '@next/swc-darwin-x64': 16.1.5
-      '@next/swc-linux-arm64-gnu': 16.1.5
-      '@next/swc-linux-arm64-musl': 16.1.5
-      '@next/swc-linux-x64-gnu': 16.1.5
-      '@next/swc-linux-x64-musl': 16.1.5
-      '@next/swc-win32-arm64-msvc': 16.1.5
-      '@next/swc-win32-x64-msvc': 16.1.5
+      '@next/swc-darwin-arm64': 16.2.10
+      '@next/swc-darwin-x64': 16.2.10
+      '@next/swc-linux-arm64-gnu': 16.2.10
+      '@next/swc-linux-arm64-musl': 16.2.10
+      '@next/swc-linux-x64-gnu': 16.2.10
+      '@next/swc-linux-x64-musl': 16.2.10
+      '@next/swc-win32-arm64-msvc': 16.2.10
+      '@next/swc-win32-x64-msvc': 16.2.10
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.0
       sharp: 0.34.5
@@ -18838,6 +18899,13 @@ snapshots:
     optionalDependencies:
       pg-cloudflare: 1.3.0
 
+  pglite-prisma-adapter@0.6.1(@electric-sql/pglite@0.3.16)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)):
+    dependencies:
+      '@electric-sql/pglite': 0.3.16
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@prisma/driver-adapter-utils': 6.10.1
+      postgres-array: 3.0.4
+
   pglite-prisma-adapter@0.6.1(@electric-sql/pglite@0.3.16)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)):
     dependencies:
       '@electric-sql/pglite': 0.3.16
@@ -19042,6 +19110,24 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': 7.8.0(magicast@0.5.2)
+      '@prisma/dev': 0.24.3(typescript@5.9.3)
+      '@prisma/engines': 7.8.0
+      '@prisma/studio-core': 0.27.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      mysql2: 3.15.3
+      postgres: 3.4.7
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - magicast
+      - react
+      - react-dom
+    optional: true
 
   prisma@7.8.0(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
@@ -20694,28 +20780,28 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  vite-plugin-storybook-nextjs@3.2.4(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-storybook-nextjs@3.2.4(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(storybook@10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook: 10.3.3(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-tsconfig-paths: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-tsconfig-paths: 5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 6.4.1(@types/node@18.19.130)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 6.4.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
Active `cacheComponents: true` (Next.js 16.2) et corrige les contaminations du graphe d'imports qui empêchaient le cache public, donc le PPR et le rendu statique... :fearful: 

Ce qui veut dire que _tout_ le site était rendu dynamiquement

**Before**
<img width="1768" height="1648" alt="image" src="https://github.com/user-attachments/assets/b11f528a-86ab-4b52-b3d0-127d7e1c72e5" />

**After**

<img width="1768" height="1648" alt="image" src="https://github.com/user-attachments/assets/9a7dd601-5051-4e08-b278-3bb4a342435d" />


## Contexte

`cacheComponents: true` active le Partial Prerendering et la directive `'use cache'`. Mais toute API dynamique de Next.js (`headers()`, `cookies()`, `draftMode()`, `connection()`) dans le graphe d'imports d'un layout contamine l'ensemble de la route, forçant `Cache-Control: private`. Ce n'est pas bloquant : le shell PPR est déjà mis en cache côté serveur Next.js, ce qui constitue une amélioration même sans `Cache-Control` public. Le `Cache-Control` public (CDN) suivra dans le volet Nginx.

À terme, pour les parties du site qui n'en ont pas besoin (blog, pages statiques), on pourra construire des layouts dédiés sans ces APIs, ou isoler les composants dynamiques via `next/dynamic` + `ssr: false`.

## Changements

**Root layout** — `fallback={null}` sur `<Suspense>` autour de `<Trackers>`. Sans `fallback`, le `<Suspense>` bloque le shell PPR au lieu de créer un trou dynamique.

**not-found.tsx / Route404** — Extrait `LogoHeader` (pur, sans API dynamique) et supprime l'import de `HeaderServer`. `not-found.tsx` est global : il est rendu dans le contexte du root layout. L'ancien import de `HeaderServer` → `MySpaceButton` → `getUserSession()` → `headers()` marquait **toutes** les routes `Cache-Control: private`.

**HeaderServer** — Utilise `LogoHeader` (DRY) + `fallback={null}` sur `<Suspense>` autour de `MySpaceButton`.

**fetchBanner** — Remplace `await connection()` (workaround Phase A) par `'use cache'` + `cacheLife('hours')`.

**i18nConfig** — `serverSetCookie: 'if-empty'` pour éviter que le proxy ne pose `NEXT_LOCALE` à chaque réponse → `Cache-Control: private`.

## Suite

Le cache public des pages statiques (mentions-légales, CGU, etc.) sera géré côté Nginx via `proxy_cache` avec ségrégation auth/anon.