### PR TITLE
⚡️ Cache the landing page and tutorial for anonymous users

### DIFF
--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -5,9 +5,9 @@ proxy_cache_path /var/cache/nginx levels=1:2
                  keys_zone=ngc_cache:500m
                  max_size=30g inactive=3d use_temp_path=off;
 
-map $cookie_ngc_session $ngc_auth {
-    ""       "anon";
-    default  "auth";
+map $cookie_ngc_session $ngc_is_auth {
+    ""       0;
+    default  1;
 }
 
 upstream scalingo {
@@ -68,11 +68,22 @@ server {
         proxy_cache_lock on;
     }
 
+    location ~ ^/(fr|en)(/simulateur/tutoriel|/?)$ {
+        proxy_pass https://scalingo;
+
+        proxy_cache_key "$scheme$request_method$host$request_uri$ngc_is_auth";
+        proxy_cache_lock on;
+        proxy_cache_background_update on;
+        proxy_ignore_headers Cache-Control;
+        proxy_cache_valid 200 30m;
+        proxy_cache_bypass $ngc_is_auth$http_upgrade;
+        proxy_no_cache $ngc_is_auth$http_upgrade;
+    }
+
     location / {
         proxy_pass https://scalingo;
         limit_req zone=web burst=20 nodelay;
 
-        proxy_cache_key "$scheme$request_method$host$request_uri$ngc_auth";
         proxy_cache_lock on;
         proxy_cache_background_update on;
         proxy_cache_bypass $http_upgrade;


### PR DESCRIPTION
## Why

Next.js envoie `Cache-Control: private` pour toutes les pages dynamiques, ce qui empêche Nginx de mettre en cache même les pages publiques comme la page d'accueil et le tutoriel. Pour les utilisateurs anonymes, ces pages ont un contenu identique. La page d'accueil et le tutoriel représentent respectivement ~19K et ~36K visiteurs uniques par mois (données PostHog, 30 jours).

## What

Un nouveau bloc `location ~` dans la config Nginx qui applique `proxy_ignore_headers Cache-Control` **uniquement** sur :
- `/(fr|en)/?` (page d'accueil)
- `/(fr|en)/simulateur/tutoriel` (tutoriel)

Ces deux routes sont regroupées dans une regex combinée : `^/(fr|en)(/simulateur/tutoriel|/?)$`

### Détails

- `proxy_ignore_headers Cache-Control` → Nginx ignore le `private` de Next.js pour sa propre couche de cache
- `proxy_cache_valid 200 30m` → TTL de 30 minutes
- `proxy_cache_bypass $ngc_is_auth$http_upgrade` + `proxy_no_cache $ngc_is_auth$http_upgrade` → les utilisateurs authentifiés (cookie `ngc_session`) bypass le cache en lecture ET écriture
- La clé de cache inclut `$ngc_is_auth` (0/1) pour séparer les entrées anon/auth
- Le `location /` par défaut **ne change pas** — il continue de respecter le `Cache-Control` upstream (pas de `proxy_ignore_headers`)

### Map simplifiée

La map `$ngc_auth` ("anon"/"auth") est remplacée par `$ngc_is_auth` (0/1), compatible avec `proxy_cache_bypass`/`proxy_no_cache` qui exigent la valeur "0" pour ne pas bypasser.

## Test plan

```bash
# Page catégorie 2 anonyme → HIT au 2e appel
curl -sI https://preprod.nosgestesclimat.fr/fr/simulateur/tutoriel | grep x-cache-status

# Page catégorie 2 avec cookie session → BYPASS
curl -sI -H "Cookie: ngc_session=fake" https://preprod.nosgestesclimat.fr/fr/simulateur/tutoriel | grep x-cache-status

# Accueil → HIT
curl -sI https://preprod.nosgestesclimat.fr/fr/ | grep x-cache-status
```

La CI valide automatiquement la syntaxe via `nginx -t`.

## Spec

La spécification complète est dans `.scratch/cache-middleware-spec.md`.