### PR TITLE
🐛 Exclure les redirections /fr du cache Nginx

### DIFF
--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -68,7 +68,7 @@ server {
         proxy_cache_lock on;
     }
 
-    location ~ ^/(fr|en)(/simulateur/tutoriel|/?)$ {
+    location ~ ^/(en/)?(simulateur/tutoriel)?$ {
         proxy_pass https://scalingo;
 
         proxy_cache_key "$scheme$request_method$host$request_uri$ngc_is_auth";


### PR DESCRIPTION
## Why

La PR #1946 a introduit le cache Nginx pour la landing page et le tutoriel, mais la regex `^/(fr|en)(/simulateur/tutoriel|/?)$` incluait les URLs `/fr/` et `/fr/simulateur/tutoriel` — qui sont des redirections 307 vers `/` et `/simulateur/tutoriel` (la locale `fr` est la locale par défaut, donc le middleware enlève le préfixe).

Cacher une redirection 307 est incorrect : la locale de destination dépend de chaque utilisateur.

## What

Remplace la regex par `^/(en/)?(simulateur/tutoriel)?$` qui ne matche que :
- `/` et `/simulateur/tutoriel` (locale par défaut `fr`, sans préfixe)
- `/en/` et `/en/simulateur/tutoriel` (locale `en`, avec préfixe)

Les URLs sans trailing slash (`/en`, `/fr`, `/fr/`) ne sont pas matchées → pas cachées → la 307 passe par l'upstream comme avant.