### PR TITLE
⚡️ Proxy and cache S3 static assets through Nginx

### DIFF
--- a/apps/server/scalingo.json
+++ b/apps/server/scalingo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/Scalingo/developers-documentation/refs/heads/master/scalingo.schema.json",
   "name": "nosgestesclimat-server",
-  "logo": "https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png",
+  "logo": "/_static/cms/petit_logo_006dd01955.png",
   "repository": "https://github.com/incubateur-ademe/nosgestesclimat-app",
   "website": "https://server.nosgestesclimat.fr",
   "formation": {

--- a/apps/site/config/remoteImagesPatterns.ts
+++ b/apps/site/config/remoteImagesPatterns.ts
@@ -37,16 +37,4 @@ export const remoteImagesPatterns: RemotePattern[] = [
     port: '',
     pathname: '/cms/**',
   },
-  {
-    protocol: 'https',
-    hostname: 'nosgestesclimat-prod.s3.fr-par.scw.cloud',
-    port: '',
-    pathname: '/cms/**',
-  },
-  {
-    protocol: 'https',
-    hostname: 's3.fr-par.scw.cloud',
-    port: '',
-    pathname: '/nosgestesclimat-prod/cms/**',
-  },
 ]

--- a/apps/site/public/manifest.webmanifest
+++ b/apps/site/public/manifest.webmanifest
@@ -7,7 +7,7 @@
   "theme_color": "#4949ba",
   "icons": [
     {
-      "src": "https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/logo_c5817128a3.svg",
+      "src": "/_static/cms/logo_c5817128a3.svg",
       "sizes": "144x144",
       "type": "image/svg+xml"
     }

--- a/apps/site/scalingo.json
+++ b/apps/site/scalingo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/Scalingo/developers-documentation/refs/heads/master/scalingo.schema.json",
   "name": "nosgestesclimat-site",
-  "logo": "https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png",
+  "logo": "/_static/cms/petit_logo_006dd01955.png",
   "repository": "https://github.com/incubateur-ademe/nosgestesclimat-app",
   "website": "https://nosgestesclimat.fr",
   "formation": {

--- a/apps/site/src/app/[locale]/(server)/(large)/(user-account)/(login)/_components/ColourBlocks.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/(user-account)/(login)/_components/ColourBlocks.tsx
@@ -26,7 +26,7 @@ export default function ColourBlock({ highlights, className }: Props) {
       <div className="mt-14">
         <img
           className="w-full"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/visuel_login_cbf2f03684.svg"
+          src="/_static/cms/visuel_login_cbf2f03684.svg"
           alt=""
         />
       </div>

--- a/apps/site/src/app/[locale]/(server)/(large)/organisations/[orgaSlug]/_components/myPolls/AddPollCard.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/organisations/[orgaSlug]/_components/myPolls/AddPollCard.tsx
@@ -19,7 +19,7 @@ export default function AddPollCard({ hasNoPollsYet }: Props) {
         href={`/organisations/${orgaSlug as string}/creer-campagne/informations`}
         highlight={!!hasNoPollsYet}
         color={hasNoPollsYet ? 'primary' : 'secondary'}
-        imageSrc="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_people_raising_arm_fe915601cd.png"
+        imageSrc="/_static/cms/medium_people_raising_arm_fe915601cd.png"
         imageAlt=""
         label={<Trans>Créer un test collectif</Trans>}
         icon={

--- a/apps/site/src/app/[locale]/(server)/(large)/organisations/[orgaSlug]/campagnes/[pollSlug]/_components/CommunicationKit.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/organisations/[orgaSlug]/campagnes/[pollSlug]/_components/CommunicationKit.tsx
@@ -49,7 +49,7 @@ export default function CommunicationKit() {
       <div className="relative mx-auto h-70 w-60 md:mx-0 md:mr-16 md:min-w-75">
         <div className="absolute inset-0">
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/illu_1_kit_communication_a6321fe7ec.png"
+            src="/_static/cms/illu_1_kit_communication_a6321fe7ec.png"
             width="200"
             height="200"
             className="border border-slate-300 object-contain"
@@ -58,7 +58,7 @@ export default function CommunicationKit() {
         </div>
         <div className="absolute top-1/2 right-0 z-10 -translate-y-1/2">
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/illu_2_kit_communication_e7769e5e6b.png"
+            src="/_static/cms/illu_2_kit_communication_e7769e5e6b.png"
             width="150"
             height="150"
             alt=""

--- a/apps/site/src/app/[locale]/(server)/(large)/organisations/[orgaSlug]/campagnes/[pollSlug]/_components/ShareSection.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/organisations/[orgaSlug]/campagnes/[pollSlug]/_components/ShareSection.tsx
@@ -58,7 +58,7 @@ export default function ShareSection({ poll, className, title }: Props) {
 
         <Card className="bg-primary-100 flex w-full flex-col items-center justify-center border-0 p-8 shadow-none">
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/bb1a673c20064abdd0ccd02c73467f2f30c128f5_adc1e8558e.png"
+            src="/_static/cms/bb1a673c20064abdd0ccd02c73467f2f30c128f5_adc1e8558e.png"
             width="48"
             height="48"
             className="mb-6"

--- a/apps/site/src/app/[locale]/(server)/(large)/organisations/[orgaSlug]/creer-campagne/_hooks/useCreatePollStep2.ts
+++ b/apps/site/src/app/[locale]/(server)/(large)/organisations/[orgaSlug]/creer-campagne/_hooks/useCreatePollStep2.ts
@@ -20,8 +20,7 @@ export const pollModes = [
     descriptionKey: 'collectiveTest.mode.standard.description',
     descriptionDefault:
       'Le test classique, pour tous les citoyennes et citoyens',
-    imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_carbone_achats_be9fd99289.svg',
+    imageSrc: '/_static/cms/empreinte_carbone_achats_be9fd99289.svg',
     imageAlt: 'Illustration mode standard',
   },
   {
@@ -30,8 +29,7 @@ export const pollModes = [
     titleDefault: 'Mode scolaire',
     descriptionKey: 'collectiveTest.mode.scolaire.description',
     descriptionDefault: 'Le test adapté aux jeunes (collège, lycée)',
-    imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_children_holding_hand_6951392e78.png',
+    imageSrc: '/_static/cms/medium_children_holding_hand_6951392e78.png',
     imageAlt: 'Illustration mode scolaire',
   },
 ] as const

--- a/apps/site/src/app/[locale]/(server)/(large)/organisations/_components/HeroSection.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/organisations/_components/HeroSection.tsx
@@ -49,7 +49,7 @@ export default function HeroSection() {
       <div>
         <Image
           className="self-start"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_people_with_paperboard_9c8d47f4b3.png"
+          src="/_static/cms/medium_people_with_paperboard_9c8d47f4b3.png"
           width="400"
           height="400"
           alt=""

--- a/apps/site/src/app/[locale]/(server)/(large)/organisations/_components/IllustratedPointsList.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/organisations/_components/IllustratedPointsList.tsx
@@ -30,7 +30,7 @@ export default function IllustratedPointsList({ locale }: { locale: string }) {
           <div className="mx-auto flex max-w-full items-end overflow-hidden rounded-xl bg-gray-100 px-6 pt-6 md:w-104">
             <div className="mx-auto mt-4 flex items-end rounded-t-md bg-white p-4 pb-0 shadow-xs">
               <Image
-                src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_tutoriel_276d608be8.png"
+                src="/_static/cms/medium_tutoriel_276d608be8.png"
                 width="300"
                 height="200"
                 alt=""
@@ -67,7 +67,7 @@ export default function IllustratedPointsList({ locale }: { locale: string }) {
           <div className="mx-auto flex max-w-full items-end overflow-hidden rounded-xl bg-gray-100 px-6 pt-6 md:w-104">
             <div className="w-full">
               <Image
-                src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_orga_visuel_2_43f01617de.png"
+                src="/_static/cms/medium_orga_visuel_2_43f01617de.png"
                 width="360"
                 height="500"
                 alt=""

--- a/apps/site/src/app/[locale]/(server)/(large)/organisations/_components/VisuelIframe.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/organisations/_components/VisuelIframe.tsx
@@ -9,7 +9,7 @@ export default function VisuelIframe() {
       <div className="absolute -bottom-[8%] left-[-16%] flex w-full -rotate-[15deg] items-end rounded-t-md bg-white p-2 pb-0 shadow-md">
         <Image
           className="rounded-xs"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_orga_visuel_3_2f5ec010f4.png"
+          src="/_static/cms/medium_orga_visuel_3_2f5ec010f4.png"
           width="300"
           height="200"
           alt=""
@@ -20,7 +20,7 @@ export default function VisuelIframe() {
       <div className="absolute right-[-16%] -bottom-[8%] flex w-full rotate-[15deg] items-end rounded-t-md bg-white p-2 pb-0 shadow-md">
         <Image
           className="rounded-xs"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_orga_visuel_3_2f5ec010f4.png"
+          src="/_static/cms/medium_orga_visuel_3_2f5ec010f4.png"
           width="300"
           height="200"
           alt=""
@@ -31,7 +31,7 @@ export default function VisuelIframe() {
       <div className="absolute bottom-0 left-1/2 flex w-full -translate-x-1/2 items-end rounded-t-md bg-white p-2 pb-0 shadow-md">
         <Image
           className="rounded-xs"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_orga_visuel_3_2f5ec010f4.png"
+          src="/_static/cms/medium_orga_visuel_3_2f5ec010f4.png"
           width="260"
           height="200"
           alt=""

--- a/apps/site/src/app/[locale]/(server)/(narrow)/contact/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/(narrow)/contact/page.tsx
@@ -53,7 +53,7 @@ export default async function Contact({ params }: DefaultPageProps) {
 
         <Image
           className="max-w-[50vw] self-start"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_delivering_mail_b981de31a3.png"
+          src="/_static/cms/medium_delivering_mail_b981de31a3.png"
           width="300"
           height="400"
           alt=""

--- a/apps/site/src/app/[locale]/(server)/(narrow)/international/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/(narrow)/international/page.tsx
@@ -38,7 +38,7 @@ export default async function International({ params }: DefaultPageProps) {
             />
 
             <Image
-              src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_international_illustration_b4030014c1.jpeg"
+              src="/_static/cms/medium_international_illustration_b4030014c1.jpeg"
               alt=""
               className="mx-auto max-w-12 py-8 md:hidden"
               width="100"
@@ -64,7 +64,7 @@ export default async function International({ params }: DefaultPageProps) {
           </div>
 
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_international_illustration_b4030014c1.jpeg"
+            src="/_static/cms/medium_international_illustration_b4030014c1.jpeg"
             alt=""
             aria-hidden="true"
             className="mx-auto hidden max-w-md p-8 md:block"
@@ -107,7 +107,7 @@ export default async function International({ params }: DefaultPageProps) {
                 )}>
                 <Image
                   alt="Electricity Maps"
-                  src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/electricitymaps_4108b9d71a.svg"
+                  src="/_static/cms/electricitymaps_4108b9d71a.svg"
                   className="ml-2 h-4"
                   width="100"
                   height="100"

--- a/apps/site/src/app/[locale]/(server)/(narrow)/nos-relais/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/(narrow)/nos-relais/page.tsx
@@ -106,7 +106,7 @@ export default async function OurPartners({
           alt={t(
             'Un grand-père et sa petite-fille au cinéma, mangeant du pop-corn.'
           )}
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/at_the_cinema_b2d25b4202.svg"
+          src="/_static/cms/at_the_cinema_b2d25b4202.svg"
         />
       </div>
 

--- a/apps/site/src/app/[locale]/(server)/(narrow)/nouveautes/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/(narrow)/nouveautes/page.tsx
@@ -51,7 +51,7 @@ export default async function Releases({ params }: DefaultPageProps) {
 
         <Image
           className="ml-auto w-32 md:-mt-4 md:w-48"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_girl_cooking_fa71604f8d.png"
+          src="/_static/cms/medium_girl_cooking_fa71604f8d.png"
           width="200"
           height="400"
           alt={t('Une femme préparant un bon petit plat.')}

--- a/apps/site/src/app/[locale]/(server)/(narrow)/questions-frequentes/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/(narrow)/questions-frequentes/page.tsx
@@ -45,7 +45,7 @@ export default async function FAQPage({
             '@type': 'Organization',
             url: 'https://nosgestesclimat.fr',
             name: 'Nos Gestes Climat',
-            logo: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png',
+            logo: '/_static/cms/petit_logo_006dd01955.png',
           },
           {
             '@context': 'https://schema.org',
@@ -88,7 +88,7 @@ export default async function FAQPage({
 
         <Image
           className="-mt-4 ml-auto w-48 self-start md:w-full"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_children_holding_hand_6951392e78.png"
+          src="/_static/cms/medium_children_holding_hand_6951392e78.png"
           width="300"
           height="400"
           alt={t("Des enfants sortant de l'école en se tenant la main.")}

--- a/apps/site/src/app/[locale]/(server)/blog/page.tsx
+++ b/apps/site/src/app/[locale]/(server)/blog/page.tsx
@@ -117,7 +117,7 @@ export default async function BlogHomePage({
             '@type': 'Organization',
             url: 'https://nosgestesclimat.fr',
             name: 'Nos Gestes Climat',
-            logo: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png',
+            logo: '/_static/cms/petit_logo_006dd01955.png',
           },
         ]}
       />
@@ -131,7 +131,7 @@ export default async function BlogHomePage({
               image
                 ? { url: image.url }
                 : {
-                    url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_girl_reading_newspaper_d171290d3d.png',
+                    url: '/_static/cms/medium_girl_reading_newspaper_d171290d3d.png',
                   }
             }
           />

--- a/apps/site/src/app/[locale]/_components/CollectivelyCommit.tsx
+++ b/apps/site/src/app/[locale]/_components/CollectivelyCommit.tsx
@@ -44,7 +44,7 @@ export default async function CollectivelyCommit({
           </p>
 
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/engagement_collectif_pour_le_climat_4f8f1edfc1.svg"
+            src="/_static/cms/engagement_collectif_pour_le_climat_4f8f1edfc1.svg"
             alt=""
             className="mb-10"
             width={600}

--- a/apps/site/src/app/[locale]/_components/DidYouKnowMainLanding.tsx
+++ b/apps/site/src/app/[locale]/_components/DidYouKnowMainLanding.tsx
@@ -23,7 +23,7 @@ export default function DidYouKnowMainLanding({
         slides={[
           {
             illustration:
-              'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_ordinateur_392d915ff0.svg',
+              '/_static/cms/icone_ordinateur_392d915ff0.svg',
             content: (
               <Trans locale={locale}>
                 L'empreinte moyenne d'un Français est de{' '}
@@ -37,7 +37,7 @@ export default function DidYouKnowMainLanding({
           },
           {
             illustration:
-              'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_jeans_7373ebf3c3.svg',
+              '/_static/cms/icone_jeans_7373ebf3c3.svg',
             content: (
               <Trans locale={locale}>
                 La production d'un jean nécessite près de{' '}
@@ -51,7 +51,7 @@ export default function DidYouKnowMainLanding({
           },
           {
             illustration:
-              'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_goutte_eau_e6a89fd5e0.svg',
+              '/_static/cms/icone_goutte_eau_e6a89fd5e0.svg',
             content: (
               <Trans locale={locale}>
                 L'empreinte eau moyenne d'un français se compte{' '}
@@ -65,7 +65,7 @@ export default function DidYouKnowMainLanding({
           },
           {
             illustration:
-              'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_avion_39cf1c300c.svg',
+              '/_static/cms/icone_avion_39cf1c300c.svg',
             content: (
               <Trans locale={locale}>
                 Un aller-retour Paris-Athènes en avion représente{' '}

--- a/apps/site/src/app/[locale]/_components/InteractiveIllustration.tsx
+++ b/apps/site/src/app/[locale]/_components/InteractiveIllustration.tsx
@@ -10,7 +10,7 @@ export default function InteractiveIllustration() {
   return (
     <div className="relative mx-auto sm:max-w-[380px] md:max-w-none">
       <Image
-        src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_carbone_eau_objets_du_quotidien_72c0224fcc.svg"
+        src="/_static/cms/empreinte_carbone_eau_objets_du_quotidien_72c0224fcc.svg"
         alt={t(
           "Une fille tapant sur son ordinateur, entouré d'objets aux empreintes carbone et eau variées."
         )}

--- a/apps/site/src/app/[locale]/_components/Mobilise.tsx
+++ b/apps/site/src/app/[locale]/_components/Mobilise.tsx
@@ -38,7 +38,7 @@ export default async function Mobilise({ locale }: { locale: string }) {
 
         <div className="order-first py-8 md:order-last">
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/comparer_empreinte_carbone_et_eau_entre_amis_ddbfa5e83d.svg"
+            src="/_static/cms/comparer_empreinte_carbone_et_eau_entre_amis_ddbfa5e83d.svg"
             alt=""
             width={500}
             height={500}
@@ -49,7 +49,7 @@ export default async function Mobilise({ locale }: { locale: string }) {
       <div className="flex flex-col items-center justify-between gap-6 md:flex-row md:gap-24">
         <div className="py-14">
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/reflechir_impacts_de_son_empreinte_en_entreprise_7a723d7c8b.svg"
+            src="/_static/cms/reflechir_impacts_de_son_empreinte_en_entreprise_7a723d7c8b.svg"
             alt=""
             width={500}
             height={500}

--- a/apps/site/src/app/[locale]/_components/TwoFootprints.tsx
+++ b/apps/site/src/app/[locale]/_components/TwoFootprints.tsx
@@ -11,7 +11,7 @@ const TwoGraphsIllustration = dynamic(
   {
     loading: () => (
       <Image
-        src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_graphiques_empreinte_carbone_eau_fr_7df50f7102.png"
+        src="/_static/cms/medium_graphiques_empreinte_carbone_eau_fr_7df50f7102.png"
         className="hidden md:block"
         alt="Deux représentations graphiques de l'empreinte carbone et eau"
         width={600}
@@ -26,7 +26,7 @@ const CarbonGraphIllustration = dynamic(
   {
     loading: () => (
       <Image
-        src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_graphique_empreinte_carbone_fr_5077492f48.png"
+        src="/_static/cms/medium_graphique_empreinte_carbone_fr_5077492f48.png"
         alt="Graphique de l'empreinte carbone"
         width={300}
         height={300}
@@ -40,7 +40,7 @@ const WaterGraphIllustration = dynamic(
   {
     loading: () => (
       <Image
-        src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_graphique_empreinte_eau_fr_de3e685ba4.png"
+        src="/_static/cms/medium_graphique_empreinte_eau_fr_de3e685ba4.png"
         alt="Graphique de l'empreinte eau"
         width={300}
         height={300}

--- a/apps/site/src/app/[locale]/_components/twoFootprints/LocalizedCarbonGraphIllustration.tsx
+++ b/apps/site/src/app/[locale]/_components/twoFootprints/LocalizedCarbonGraphIllustration.tsx
@@ -7,10 +7,10 @@ import Image from 'next/image'
 const getLocalisedSrc = (locale: Locale) => {
   switch (locale) {
     case 'en':
-      return 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/graphique_empreinte_carbone_en_73e92afb6f.png'
+      return '/_static/cms/graphique_empreinte_carbone_en_73e92afb6f.png'
     case 'fr':
     default:
-      return 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/graphique_empreinte_carbone_fr_5077492f48.png'
+      return '/_static/cms/graphique_empreinte_carbone_fr_5077492f48.png'
   }
 }
 

--- a/apps/site/src/app/[locale]/_components/twoFootprints/LocalizedTwoGraphIllustration.tsx
+++ b/apps/site/src/app/[locale]/_components/twoFootprints/LocalizedTwoGraphIllustration.tsx
@@ -7,10 +7,10 @@ import Image from 'next/image'
 const getLocalisedSrc = (locale: Locale) => {
   switch (locale) {
     case 'en':
-      return 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/graphiques_empreinte_carbone_eau_en_73dff81136.png'
+      return '/_static/cms/graphiques_empreinte_carbone_eau_en_73dff81136.png'
     case 'fr':
     default:
-      return 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/graphiques_empreinte_carbone_eau_fr_7df50f7102.png'
+      return '/_static/cms/graphiques_empreinte_carbone_eau_fr_7df50f7102.png'
   }
 }
 

--- a/apps/site/src/app/[locale]/_components/twoFootprints/LocalizedWaterGraphIllustration.tsx
+++ b/apps/site/src/app/[locale]/_components/twoFootprints/LocalizedWaterGraphIllustration.tsx
@@ -7,10 +7,10 @@ import Image from 'next/image'
 const getLocalisedSrc = (locale: Locale) => {
   switch (locale) {
     case 'en':
-      return 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/graphique_empreinte_eau_en_9f638fe3e3.png'
+      return '/_static/cms/graphique_empreinte_eau_en_9f638fe3e3.png'
     case 'fr':
     default:
-      return 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/graphique_empreinte_eau_fr_de3e685ba4.png'
+      return '/_static/cms/graphique_empreinte_eau_fr_de3e685ba4.png'
   }
 }
 

--- a/apps/site/src/app/[locale]/accueil-iframe/page.tsx
+++ b/apps/site/src/app/[locale]/accueil-iframe/page.tsx
@@ -23,7 +23,7 @@ export const generateMetadata = getCommonMetadata({
   },
   robots: noIndexObject,
   image:
-    'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/calculer_empreinte_carbone_et_eau_ecccc9a625.png',
+    '/_static/cms/calculer_empreinte_carbone_et_eau_ecccc9a625.png',
 })
 
 export default async function Homepage({ params }: DefaultPageProps) {

--- a/apps/site/src/app/[locale]/campagne-partenaire/[pollSlug]/_components/PartnerCampaignContent.tsx
+++ b/apps/site/src/app/[locale]/campagne-partenaire/[pollSlug]/_components/PartnerCampaignContent.tsx
@@ -92,7 +92,7 @@ export default function PartnerCampaignContent({
             <Image
               src={
                 partnerCampaign.image?.url ??
-                'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/girl_holding_earth_3373a344b0.svg'
+                '/_static/cms/girl_holding_earth_3373a344b0.svg'
               }
               width={300}
               height={300}
@@ -105,7 +105,7 @@ export default function PartnerCampaignContent({
           <Image
             src={
               partnerCampaign.image?.url ??
-              'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/girl_holding_earth_3373a344b0.svg'
+              '/_static/cms/girl_holding_earth_3373a344b0.svg'
             }
             width={400}
             height={300}

--- a/apps/site/src/app/[locale]/documentation/_components/DocumentationLanding.tsx
+++ b/apps/site/src/app/[locale]/documentation/_components/DocumentationLanding.tsx
@@ -60,7 +60,7 @@ export default async function DocumentationLanding({
         {/* Displayed on mobile only */}
         <Image
           className="ml-auto h-auto w-48 md:hidden md:w-full"
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_girl_reading_newspaper_d171290d3d.png"
+          src="/_static/cms/medium_girl_reading_newspaper_d171290d3d.png"
           width="400"
           height="300"
           alt={t(
@@ -71,7 +71,7 @@ export default async function DocumentationLanding({
         <SquareImageContainer className="hidden max-w-96 md:flex">
           <Image
             className="ml-auto h-auto w-48 md:w-full"
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_girl_reading_newspaper_d171290d3d.png"
+            src="/_static/cms/medium_girl_reading_newspaper_d171290d3d.png"
             width="400"
             height="300"
             alt={t(

--- a/apps/site/src/app/[locale]/empreinte-carbone/_components/DailyGestureCarbonFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-carbone/_components/DailyGestureCarbonFootprint.tsx
@@ -43,7 +43,7 @@ export default async function DailyGestureCarbonFootprint({
       gestures={{
         [gesturesKeysForTranslation.transport]: {
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_carbone_velo_a7262d1e2e.svg',
+            '/_static/cms/empreinte_carbone_velo_a7262d1e2e.svg',
           imageAlt: t(
             'Une mère et son fils sur un vélo, illustrant la possibilité de réduire son empreinte carbone en privilégiant les transports doux'
           ),
@@ -55,7 +55,7 @@ export default async function DailyGestureCarbonFootprint({
         },
         [gesturesKeysForTranslation.alimentation]: {
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_carbone_cuisine_alimentation_6c7f46b1d6.svg',
+            '/_static/cms/empreinte_carbone_cuisine_alimentation_6c7f46b1d6.svg',
           imageAlt: t(
             "Une jeune femme cuisinant, illustrant l'importance de ses choix d'alimentation dans le calcul de son empreinte carbone"
           ),
@@ -67,7 +67,7 @@ export default async function DailyGestureCarbonFootprint({
         },
         [gesturesKeysForTranslation.logement]: {
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_carbone_logement_0c8aefd3a5.svg',
+            '/_static/cms/empreinte_carbone_logement_0c8aefd3a5.svg',
           imageAlt: t(
             "Une jeune femme lisant un journal, illustrant l'empreinte carbone liée à son logement"
           ),
@@ -82,7 +82,7 @@ export default async function DailyGestureCarbonFootprint({
         },
         [gesturesKeysForTranslation.consommation]: {
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_carbone_achats_be9fd99289.svg',
+            '/_static/cms/empreinte_carbone_achats_be9fd99289.svg',
           imageAlt: t(
             "Une jeune femme réfléchissant à ses choix de consommation, illustrant l'importance de ses achats dans le calcul de son empreinte carbone"
           ),

--- a/apps/site/src/app/[locale]/empreinte-carbone/_components/DidYouKnowCarbonFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-carbone/_components/DidYouKnowCarbonFootprint.tsx
@@ -9,7 +9,7 @@ export default function DidYouKnowCarbon({ locale }: { locale: string }) {
       slides={[
         {
           illustration:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_trophee_32ee5f6d9a.svg',
+            '/_static/cms/icone_trophee_32ee5f6d9a.svg',
           content: (
             <Trans locale={locale}>
               L'empreinte carbone moyenne d'un français est de{' '}
@@ -23,7 +23,7 @@ export default function DidYouKnowCarbon({ locale }: { locale: string }) {
         },
         {
           illustration:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_avion_39cf1c300c.svg',
+            '/_static/cms/icone_avion_39cf1c300c.svg',
           content: (
             <Trans locale={locale}>
               Un aller-retour Paris-Athènes en avion représente{' '}

--- a/apps/site/src/app/[locale]/empreinte-carbone/_components/MotivationSectionCarbonFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-carbone/_components/MotivationSectionCarbonFootprint.tsx
@@ -35,7 +35,7 @@ export default async function MotivationSectionCarbonFootprint({
             'Passer le test'
           ),
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_calculatrice_59c4502e6f.svg',
+            url: '/_static/cms/icone_calculatrice_59c4502e6f.svg',
             alternativeText: '',
           },
           description: t(
@@ -49,7 +49,7 @@ export default async function MotivationSectionCarbonFootprint({
             'Agir au quotidien'
           ),
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_biceps_37c35c3709.svg',
+            url: '/_static/cms/icone_biceps_37c35c3709.svg',
             alternativeText: '',
           },
           description: t(
@@ -63,7 +63,7 @@ export default async function MotivationSectionCarbonFootprint({
             "S'engager collectivement"
           ),
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_poignee_de_main_8a9e5792cb.svg',
+            url: '/_static/cms/icone_poignee_de_main_8a9e5792cb.svg',
             alternativeText: '',
           },
           description: t(

--- a/apps/site/src/app/[locale]/empreinte-carbone/_components/UnderstandToActCarbonFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-carbone/_components/UnderstandToActCarbonFootprint.tsx
@@ -35,21 +35,21 @@ export default async function UnderstandToActCarbonFootprint({
           title: t('Transports : les modes à fuir, ceux à chérir'),
           href: '/blog/mobilites/transports-fuir-transports-cherir',
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/van_bus_velo_elviss_railijs_bitans_dce5c98c2c.jpg',
+            '/_static/cms/van_bus_velo_elviss_railijs_bitans_dce5c98c2c.jpg',
         },
         {
           category: t('Empreinte carbone'),
           title: t("L'empreinte carbone : une empreinte parmi d'autres !"),
           href: '/blog/environnement/carbone-empreinte-parmi-autres',
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/markus_spiske_nature_future_0398daa4ed.jpg',
+            '/_static/cms/markus_spiske_nature_future_0398daa4ed.jpg',
         },
         {
           category: t('Empreinte carbone'),
           title: t('Avez-vous déjà entendu parler de maladaptation ?'),
           href: '/blog/environnement/maladaptation',
           imageSrc:
-            'https://s3.fr-par.scw.cloud/nosgestesclimat-prod/cms/william_bossen_fonte_glaces_a3dd8ea653.jpg',
+            '/_static/cms/william_bossen_fonte_glaces_a3dd8ea653.jpg',
         },
       ]}
     />

--- a/apps/site/src/app/[locale]/empreinte-carbone/_components/WhatDoWeMeasureCarbonFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-carbone/_components/WhatDoWeMeasureCarbonFootprint.tsx
@@ -28,21 +28,21 @@ export default async function WhatDoWeMeasureCarbon({
       listItems={[
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_velo_0b190d715c.svg',
+            url: '/_static/cms/icone_velo_0b190d715c.svg',
             alternativeText: '',
           },
           title: t('landing.carbon.measure.modes', 'Vos modes de déplacement'),
         },
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_viande_b8d5c03c9b.svg',
+            url: '/_static/cms/icone_viande_b8d5c03c9b.svg',
             alternativeText: '',
           },
           title: t('landing.carbon.measure.food', 'Votre régime alimentaire'),
         },
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_bois_aa65836769.svg',
+            url: '/_static/cms/icone_bois_aa65836769.svg',
             alternativeText: '',
           },
           title: t(
@@ -53,7 +53,7 @@ export default async function WhatDoWeMeasureCarbon({
 
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_ordinateur_392d915ff0.svg',
+            url: '/_static/cms/icone_ordinateur_392d915ff0.svg',
             alternativeText: '',
           },
           title: t('landing.carbon.measure.shopping', 'Vos achats'),

--- a/apps/site/src/app/[locale]/empreinte-carbone/_components/WhatItIsCarbon.tsx
+++ b/apps/site/src/app/[locale]/empreinte-carbone/_components/WhatItIsCarbon.tsx
@@ -41,7 +41,7 @@ export default async function WhatItIsCarbon({ locale }: { locale: string }) {
         </div>
       }
       illustration={{
-        url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/expliquer_empreinte_carbone_7698ed628b.svg',
+        url: '/_static/cms/expliquer_empreinte_carbone_7698ed628b.svg',
         alternativeText: t(
           "Deux personnes accolées levant le bras en signe de succès, illustrant l'importance du collectif dans la réduction de nos empreintes carbone"
         ),

--- a/apps/site/src/app/[locale]/empreinte-carbone/page.tsx
+++ b/apps/site/src/app/[locale]/empreinte-carbone/page.tsx
@@ -46,7 +46,7 @@ export default async function CarbonFootprintLandingPage({
             '@type': 'Organization',
             url: 'https://nosgestesclimat.fr',
             name: 'Nos Gestes Climat',
-            logo: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png',
+            logo: '/_static/cms/petit_logo_006dd01955.png',
           },
           {
             '@context': 'https://schema.org',
@@ -93,7 +93,7 @@ export default async function CarbonFootprintLandingPage({
               <Image
                 width={280}
                 height={280}
-                src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/girl_holding_earth_3373a344b0.svg"
+                src="/_static/cms/girl_holding_earth_3373a344b0.svg"
                 alt=""
               />
             </div>
@@ -104,7 +104,7 @@ export default async function CarbonFootprintLandingPage({
             <Image
               width={400}
               height={400}
-              src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/girl_holding_earth_3373a344b0.svg"
+              src="/_static/cms/girl_holding_earth_3373a344b0.svg"
               alt=""
             />
           </div>

--- a/apps/site/src/app/[locale]/empreinte-eau/_components/DailyGestureWaterFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-eau/_components/DailyGestureWaterFootprint.tsx
@@ -51,7 +51,7 @@ export default async function DailyGestureWaterFootprint({
       gestures={{
         [gesturesKeysForTranslation.alimentation]: {
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_alimentation_8dce62c4e4.svg',
+            '/_static/cms/empreinte_alimentation_8dce62c4e4.svg',
           imageAlt: t(
             "Un épi de maïs et un avocat, illustrant le fait d'économiser l'eau dans l'alimentation"
           ),
@@ -63,7 +63,7 @@ export default async function DailyGestureWaterFootprint({
         },
         [gesturesKeysForTranslation.clothing]: {
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_textile_720345e437.svg',
+            '/_static/cms/empreinte_textile_720345e437.svg',
           imageAlt: t(
             "Une fille dans un magasin hésitant entre un pull en coton et un pull en lin, illustrant le fait de réduire l'utilisation d'eau des vêtements"
           ),

--- a/apps/site/src/app/[locale]/empreinte-eau/_components/DidYouKnowWaterFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-eau/_components/DidYouKnowWaterFootprint.tsx
@@ -13,7 +13,7 @@ export default function DidYouKnowWaterFootprint({
       slides={[
         {
           illustration:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_ordinateur_392d915ff0.svg',
+            '/_static/cms/icone_ordinateur_392d915ff0.svg',
           content: (
             <Trans locale={locale}>
               La production d’un ordinateur nécessite 195 000 litres d’eau.
@@ -23,7 +23,7 @@ export default function DidYouKnowWaterFootprint({
         },
         {
           illustration:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_jeans_7373ebf3c3.svg',
+            '/_static/cms/icone_jeans_7373ebf3c3.svg',
           content: (
             <Trans locale={locale}>
               L’empreinte eau d'un jean est de 30 000 litres d'eau.
@@ -33,7 +33,7 @@ export default function DidYouKnowWaterFootprint({
         },
         {
           illustration:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_oeuf_035042441c.svg',
+            '/_static/cms/icone_oeuf_035042441c.svg',
           content: (
             <Trans locale={locale}>
               Il faut 75 litres d’eau pour produire un oeuf.

--- a/apps/site/src/app/[locale]/empreinte-eau/_components/MotivationSectionWaterFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-eau/_components/MotivationSectionWaterFootprint.tsx
@@ -41,7 +41,7 @@ export default async function MotivationSectionWaterFootprint({
             'Ressources en eau douce limitées'
           ),
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_eau_c22d6f0b6e.svg',
+            url: '/_static/cms/icone_eau_c22d6f0b6e.svg',
             alternativeText: '',
           },
           description: t(
@@ -55,7 +55,7 @@ export default async function MotivationSectionWaterFootprint({
             'Pollution des eaux'
           ),
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_pollution_338f41ac90.svg',
+            url: '/_static/cms/icone_pollution_338f41ac90.svg',
             alternativeText: '',
           },
           description: t(
@@ -66,7 +66,7 @@ export default async function MotivationSectionWaterFootprint({
         {
           title: t('landing.water.motivation.items.access', "Accès à l'eau"),
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_robinet_5ac677e900.svg',
+            url: '/_static/cms/icone_robinet_5ac677e900.svg',
             alternativeText: '',
           },
           description: t(

--- a/apps/site/src/app/[locale]/empreinte-eau/_components/UnderstandToActWaterFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-eau/_components/UnderstandToActWaterFootprint.tsx
@@ -38,7 +38,7 @@ export default async function UnderstandToActWaterFootprint({
           title: t("Le lexique pour tout comprendre à l'empreinte eau"),
           href: '/blog/environnement/lexique-eau-tout-comprendre',
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_philip_junior_mail_Bp_Uk_WK_6hf_JA_unsplash_0f0f3b01c2.jpg',
+            '/_static/cms/medium_philip_junior_mail_Bp_Uk_WK_6hf_JA_unsplash_0f0f3b01c2.jpg',
         },
         {
           category: t('Empreinte eau'),
@@ -47,7 +47,7 @@ export default async function UnderstandToActWaterFootprint({
           ),
           href: '/blog/consommation/reflexes-textile-econome-empreinte-eau',
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_priscilla_du_preez_9d7a6e02a2.jpg',
+            '/_static/cms/medium_priscilla_du_preez_9d7a6e02a2.jpg',
         },
         {
           category: t('Empreinte eau'),
@@ -56,7 +56,7 @@ export default async function UnderstandToActWaterFootprint({
           ),
           href: '/blog/actualites-et-fonctionnalites/empreinte-eau-pourquoi-comment',
           imageSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_trisha_downing_champ_coton_3ffd08e0f4.jpg',
+            '/_static/cms/medium_trisha_downing_champ_coton_3ffd08e0f4.jpg',
         },
       ]}
     />

--- a/apps/site/src/app/[locale]/empreinte-eau/_components/WaterFootprintPartners.tsx
+++ b/apps/site/src/app/[locale]/empreinte-eau/_components/WaterFootprintPartners.tsx
@@ -10,7 +10,7 @@ export default function WaterFootprintPartners() {
       <Ademe className="h-auto w-10 md:w-auto" />
 
       <Image
-        src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/logo_agences_eau_8f0e7f34cb.svg"
+        src="/_static/cms/logo_agences_eau_8f0e7f34cb.svg"
         alt="Les agences de l'eau"
         width="200"
         height="200"

--- a/apps/site/src/app/[locale]/empreinte-eau/_components/WhatDoWeMeasureWaterFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-eau/_components/WhatDoWeMeasureWaterFootprint.tsx
@@ -18,7 +18,7 @@ export default async function WhatDoWeMeasureWaterFootprint({
       listItems={[
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_alimentation_b6c20e8522.svg',
+            url: '/_static/cms/icone_alimentation_b6c20e8522.svg',
             alternativeText: t(
               'Une pomme, symbolisant le lien entre eau et agriculture'
             ),
@@ -30,7 +30,7 @@ export default async function WhatDoWeMeasureWaterFootprint({
         },
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_textile_f789f577aa.svg',
+            url: '/_static/cms/icone_textile_f789f577aa.svg',
             alternativeText: t(
               "Un tee-shirt, symbolisant la consommation d'eau pour l'industrie textile"
             ),
@@ -42,7 +42,7 @@ export default async function WhatDoWeMeasureWaterFootprint({
         },
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_agriculture_fe3f833cc4.svg',
+            url: '/_static/cms/icone_agriculture_fe3f833cc4.svg',
             alternativeText: t('Un mouton, liant empreinte eau et élevage'),
           },
           title: t(
@@ -52,7 +52,7 @@ export default async function WhatDoWeMeasureWaterFootprint({
         },
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_ordinateur_392d915ff0.svg',
+            url: '/_static/cms/icone_ordinateur_392d915ff0.svg',
             alternativeText: t(
               "Un ordinateur, illustrant la consommation d'eau par le numérique"
             ),
@@ -64,7 +64,7 @@ export default async function WhatDoWeMeasureWaterFootprint({
         },
         {
           icon: {
-            url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/icone_electricite_d62b8b8914.svg',
+            url: '/_static/cms/icone_electricite_d62b8b8914.svg',
             alternativeText: t(
               "Un éclair, symbolisant la production d'électricité"
             ),

--- a/apps/site/src/app/[locale]/empreinte-eau/_components/WhatItIsWaterFootprint.tsx
+++ b/apps/site/src/app/[locale]/empreinte-eau/_components/WhatItIsWaterFootprint.tsx
@@ -50,7 +50,7 @@ export default async function WhatItIsWaterFootprint({
         </section>
       }
       illustration={{
-        url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/definition_empreinte_eau_39d3fa00e2.svg',
+        url: '/_static/cms/definition_empreinte_eau_39d3fa00e2.svg',
         alternativeText: t(
           "Une balance indiquant la quantité d'eau nécessaire pour produire un ordinateur"
         ),

--- a/apps/site/src/app/[locale]/empreinte-eau/page.tsx
+++ b/apps/site/src/app/[locale]/empreinte-eau/page.tsx
@@ -29,7 +29,7 @@ export const generateMetadata = getCommonMetadata({
     'Découvrez les litres d’eau cachés derrière chacun de vos repas, vêtements, appareils… Adoptez des actions concrètes pour réduire votre empreinte eau'
   ),
   image:
-    'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/calculer_son_empreinte_eau_9e5f8be16c.png',
+    '/_static/cms/calculer_son_empreinte_eau_9e5f8be16c.png',
   alternates: {
     canonical: '/empreinte-eau',
   },
@@ -52,7 +52,7 @@ export default async function WaterFootprintLandingPage(
             '@type': 'Organization',
             url: 'https://nosgestesclimat.fr',
             name: 'Nos Gestes Climat',
-            logo: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png',
+            logo: '/_static/cms/petit_logo_006dd01955.png',
           },
           {
             '@context': 'https://schema.org',
@@ -97,7 +97,7 @@ export default async function WaterFootprintLandingPage(
               <Image
                 width={560}
                 height={560}
-                src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/mon_empreinte_eau_79e7327871.svg"
+                src="/_static/cms/mon_empreinte_eau_79e7327871.svg"
                 alt={t(
                   "Un homme dans un magasin réfléchissant à l'empreinte eau du tee-shirt qu'il tient"
                 )}
@@ -109,7 +109,7 @@ export default async function WaterFootprintLandingPage(
           <Image
             width={560}
             height={560}
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/mon_empreinte_eau_79e7327871.svg"
+            src="/_static/cms/mon_empreinte_eau_79e7327871.svg"
             alt={t(
               "Un homme dans un magasin réfléchissant à l'empreinte eau du tee-shirt qu'il tient"
             )}

--- a/apps/site/src/app/[locale]/evenement/[id]/_components/eventTestimonies/TestimonyCard.tsx
+++ b/apps/site/src/app/[locale]/evenement/[id]/_components/eventTestimonies/TestimonyCard.tsx
@@ -19,7 +19,7 @@ export default function TestimonyCard({ testimony }: { testimony: Testimony }) {
           <Image
             src={
               testimony.author.avatarSrc ??
-              'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/user_28130c4ba4.png'
+              '/_static/cms/user_28130c4ba4.png'
             }
             alt={testimony.author.name}
             fill

--- a/apps/site/src/app/[locale]/evenement/[id]/_helpers/eventPageData.tsx
+++ b/apps/site/src/app/[locale]/evenement/[id]/_helpers/eventPageData.tsx
@@ -73,7 +73,7 @@ export function getEventPageData({
 
   return {
     detailImageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/VIGNETTE_SEDD_f711b1d37b.svg',
+      '/_static/cms/VIGNETTE_SEDD_f711b1d37b.svg',
     startDate: '2026-09-01T00:00:00+02:00',
     endDate: '2026-09-30T23:59:59+02:00',
     dynamicCounter: {
@@ -118,7 +118,7 @@ export function getEventPageData({
             'Impact Officer chez HomeExchange'
           ),
           avatarSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/elisa_papin_big_a21e5928cf.png',
+            '/_static/cms/elisa_papin_big_a21e5928cf.png',
         },
       },
       {
@@ -133,7 +133,7 @@ export function getEventPageData({
             'Responsable des relations avec les publics du Pass Culture'
           ),
           avatarSrc:
-            'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/theo_gasquet_big_780f9fce63.png',
+            '/_static/cms/theo_gasquet_big_780f9fce63.png',
         },
       },
       {
@@ -233,7 +233,7 @@ export function getEventPageData({
       ],
     },
     ctaImageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ILLUSTRATION_SEDD_e1a82fa2e2.svg',
+      '/_static/cms/ILLUSTRATION_SEDD_e1a82fa2e2.svg',
     ctaHeading: t('event.ctas.heading', "Prêt·e à rejoindre l'aventure ?"),
     ctaDescription: t(
       'event.ctas.description',

--- a/apps/site/src/app/[locale]/newsletter-confirmation/page.tsx
+++ b/apps/site/src/app/[locale]/newsletter-confirmation/page.tsx
@@ -16,7 +16,7 @@ interface SearchParams {
 export const generateMetadata = getCommonMetadata({
   title: t("Confirmation d'inscription à nos infolettres - Nos Gestes Climat"),
   image:
-    'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/calculer_empreinte_carbone_et_eau_ecccc9a625.png',
+    '/_static/cms/calculer_empreinte_carbone_et_eau_ecccc9a625.png',
   description: t(
     "2 millions de personnes ont déjà calculé leur empreinte sur le climat avec le calculateur Nos Gestes Climat ! Et vous, qu'attendez-vous pour faire le test ?"
   ),

--- a/apps/site/src/app/[locale]/page.tsx
+++ b/apps/site/src/app/[locale]/page.tsx
@@ -24,7 +24,7 @@ import TwoFootprints from './_components/TwoFootprints'
 export const generateMetadata = getCommonMetadata({
   title: t('Calculez votre empreinte carbone et eau avec Nos Gestes Climat'),
   image:
-    'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/calculer_empreinte_carbone_et_eau_ecccc9a625.png',
+    '/_static/cms/calculer_empreinte_carbone_et_eau_ecccc9a625.png',
   description: t(
     'Comme 2 millions de personnes, mesurez votre empreinte écologique en 10 minutes. Un outil gratuit pour faire le bilan et réduire vos émissions de CO2.'
   ),
@@ -52,7 +52,7 @@ export default async function Homepage({ params }: PageProps<'/[locale]'>) {
             '@type': 'Organization',
             url: 'https://nosgestesclimat.fr',
             name: 'Nos Gestes Climat',
-            logo: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png',
+            logo: '/_static/cms/petit_logo_006dd01955.png',
           },
         ]}
       />

--- a/apps/site/src/app/[locale]/simulateur/(header)/_components/AutresQuestions.tsx
+++ b/apps/site/src/app/[locale]/simulateur/(header)/_components/AutresQuestions.tsx
@@ -58,7 +58,7 @@ export default function AutresQuestions() {
                 </Trans>
               </p>
               <Image
-                src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/greenhouse_effect_5fc8193750.svg"
+                src="/_static/cms/greenhouse_effect_5fc8193750.svg"
                 alt="Effet de serre"
                 className="mx-auto w-1/3"
                 width={100}
@@ -107,7 +107,7 @@ export default function AutresQuestions() {
                   Avec une unité au nom barbare : l'équivalent CO₂. Le dioxyde
                   de carbone{' '}
                   <Image
-                    src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/co2_acd306ef6d.svg"
+                    src="/_static/cms/co2_acd306ef6d.svg"
                     alt="CO₂"
                     className="inline-block w-8"
                     width={100}
@@ -118,7 +118,7 @@ export default function AutresQuestions() {
                 </Trans>
               </p>
               <Image
-                src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/co2e_dab11345cd.svg"
+                src="/_static/cms/co2e_dab11345cd.svg"
                 alt="CO₂e"
                 className="mx-auto mb-2 w-24"
                 width={100}
@@ -166,7 +166,7 @@ export default function AutresQuestions() {
                   <Trans i18nKey={'publicodes.Tutoriel.slide2.blockquote'}>
                     D'autres gaz, surtout le méthane{' '}
                     <Image
-                      src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/methane_dcd07779af.svg"
+                      src="/_static/cms/methane_dcd07779af.svg"
                       alt="methane"
                       className="inline-block w-8"
                       width={100}
@@ -174,7 +174,7 @@ export default function AutresQuestions() {
                     />{' '}
                     et le protoxyde d'azote{' '}
                     <Image
-                      src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/n2o_33197c87d4.svg"
+                      src="/_static/cms/n2o_33197c87d4.svg"
                       alt="N2O"
                       className="inline-block w-8"
                       width={100}

--- a/apps/site/src/app/[locale]/simulateur/(header)/_components/YouthTutorial.tsx
+++ b/apps/site/src/app/[locale]/simulateur/(header)/_components/YouthTutorial.tsx
@@ -48,7 +48,7 @@ export default function YouthTutorial({ locale, buttonNext }: Props) {
 
           <div className="-mt-4 max-w-36 md:min-w-48">
             <Image
-              src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/girl_holding_earth_3373a344b0.svg"
+              src="/_static/cms/girl_holding_earth_3373a344b0.svg"
               width="180"
               height="150"
               alt=""

--- a/apps/site/src/app/[locale]/simulateur/(simulator-flow)/(root)/bilan/_components/summary/CategoryIllustration.tsx
+++ b/apps/site/src/app/[locale]/simulateur/(simulator-flow)/(root)/bilan/_components/summary/CategoryIllustration.tsx
@@ -16,31 +16,31 @@ export default function CategoryIllustration({
     switch (category) {
       case 'transport':
         return {
-          src: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_mother_and_son_on_bike_5883583982.png',
+          src: '/_static/cms/medium_mother_and_son_on_bike_5883583982.png',
           alt: '',
           className: '',
         }
       case 'alimentation':
         return {
-          src: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_girl_cooking_fa71604f8d.png',
+          src: '/_static/cms/medium_girl_cooking_fa71604f8d.png',
           alt: '',
           className: '',
         }
       case 'logement':
         return {
-          src: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_girl_reading_newspaper_d171290d3d.png',
+          src: '/_static/cms/medium_girl_reading_newspaper_d171290d3d.png',
           alt: '',
           className: 'min-w-[200px]',
         }
       case 'divers':
         return {
-          src: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_at_the_cinema_00898dd691.png',
+          src: '/_static/cms/medium_at_the_cinema_00898dd691.png',
           alt: '',
           className: '',
         }
       case 'services sociétaux':
         return {
-          src: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_children_holding_hand_6951392e78.png',
+          src: '/_static/cms/medium_children_holding_hand_6951392e78.png',
           alt: '',
           className: '',
         }

--- a/apps/site/src/app/[locale]/themes/[landingPageSlug]/page.tsx
+++ b/apps/site/src/app/[locale]/themes/[landingPageSlug]/page.tsx
@@ -94,7 +94,7 @@ export default async function ThematicLandingPage({
             '@type': 'Organization',
             url: 'https://nosgestesclimat.fr',
             name: 'Nos Gestes Climat',
-            logo: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png',
+            logo: '/_static/cms/petit_logo_006dd01955.png',
           },
 
           {

--- a/apps/site/src/components/dashboard/NoResultsBlock.tsx
+++ b/apps/site/src/components/dashboard/NoResultsBlock.tsx
@@ -40,7 +40,7 @@ export default function NoResultsBlock({ locale }: { locale: Locale }) {
 
       <div className="flex justify-center">
         <img
-          src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/engagement_collectif_pour_le_climat_4f8f1edfc1.svg"
+          src="/_static/cms/engagement_collectif_pour_le_climat_4f8f1edfc1.svg"
           alt=""
           width={340}
           className="grayscale"

--- a/apps/site/src/components/landing-pages/Partners.tsx
+++ b/apps/site/src/components/landing-pages/Partners.tsx
@@ -18,7 +18,7 @@ export default async function Partners({ locale }: { locale: string }) {
         <div>
           <Image
             priority
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/logo_abc_web_01c99cfe74.webp"
+            src="/_static/cms/logo_abc_web_01c99cfe74.webp"
             alt={t(
               'common.partners.abc.ariaLabel',
               'Association pour la transition Bas Carbone'

--- a/apps/site/src/components/layout/404.tsx
+++ b/apps/site/src/components/layout/404.tsx
@@ -25,7 +25,7 @@ export default async function Route404({ locale }: { locale: Locale }) {
                 <span className="island relative leading-none">
                   <Image
                     className="hover:animate-jump absolute -top-8 right-0 left-0 m-auto w-10 motion-reduce:hover:animate-none md:top-3 md:w-12"
-                    src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/404_bonhomme_17c7e762b9.svg"
+                    src="/_static/cms/404_bonhomme_17c7e762b9.svg"
                     width="60"
                     height="60"
                     alt={t('Un bonhomme se demandant où il est')}

--- a/apps/site/src/components/misc/Logo.tsx
+++ b/apps/site/src/components/misc/Logo.tsx
@@ -20,7 +20,7 @@ export default function Logo({ className, size = 'md' }: Props) {
   return (
     <div className={twMerge('flex items-center', className)}>
       <Image
-        src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_3x_f817f785ce.png"
+        src="/_static/cms/petit_logo_3x_f817f785ce.png"
         alt=""
         width="200"
         height="200"

--- a/apps/site/src/components/results/FootprintDetail.tsx
+++ b/apps/site/src/components/results/FootprintDetail.tsx
@@ -41,7 +41,7 @@ export default async function FootprintDetail({
             width="300"
             height="300"
             className="mx-auto w-48 md:w-72"
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/empreinte_carbone_achats_be9fd99289.svg"
+            src="/_static/cms/empreinte_carbone_achats_be9fd99289.svg"
             alt=""
           />
         </div>

--- a/apps/site/src/components/results/SaveResultsBlock.tsx
+++ b/apps/site/src/components/results/SaveResultsBlock.tsx
@@ -125,7 +125,7 @@ export default async function SaveResultsBlock({
             {user?.isAuth ? (
               <div className="flex w-full justify-center">
                 <Image
-                  src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/visuel_login_cbf2f03684.svg"
+                  src="/_static/cms/visuel_login_cbf2f03684.svg"
                   alt={t(
                     'results.saveResults.imageAlt',
                     "Exemple de courbe de progression de mon empreinte, et de répartition de l'empreinte sur les catégories transport, logement, alimentation, divers et services."

--- a/apps/site/src/components/results/actions/actionsContent/Actions.tsx
+++ b/apps/site/src/components/results/actions/actionsContent/Actions.tsx
@@ -157,7 +157,7 @@ export default function Actions({
           className="bg-primary-700 inline-flex items-center rounded-full px-4 text-sm font-medium text-white"
           aria-describedby="engagement-actions-description">
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/270_A_cc8d6cb2b7.svg"
+            src="/_static/cms/270_A_cc8d6cb2b7.svg"
             className="mr-2 align-middle invert"
             height={36}
             width={36}
@@ -205,7 +205,7 @@ export default function Actions({
           className="bg-primary-700 inline-flex items-center rounded-full px-4 text-sm font-medium text-white"
           aria-describedby="negative-actions-description">
           <Image
-            src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/26_D4_0bb5aeaf38.svg"
+            src="/_static/cms/26_D4_0bb5aeaf38.svg"
             className="mr-2 invert"
             height={36}
             width={36}

--- a/apps/site/src/components/results/groups/EmptyState.tsx
+++ b/apps/site/src/components/results/groups/EmptyState.tsx
@@ -46,7 +46,7 @@ export default function EmptyState() {
             tag="li"
             className="flex max-w-56 items-center gap-4 border-none bg-blue-50 p-6">
             <img
-              src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/environmentalism_1_0657edeb28.svg"
+              src="/_static/cms/environmentalism_1_0657edeb28.svg"
               alt=""
               width={40}
               height={40}
@@ -61,7 +61,7 @@ export default function EmptyState() {
             tag="li"
             className="flex items-center gap-4 border-none bg-blue-50 p-6 lg:max-w-40 lg:-translate-y-4">
             <img
-              src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/cheers_c44311442b.svg"
+              src="/_static/cms/cheers_c44311442b.svg"
               alt=""
               width={40}
               height={40}
@@ -76,7 +76,7 @@ export default function EmptyState() {
             tag="li"
             className="flex max-w-64 items-center gap-4 border-none bg-blue-50 p-6">
             <img
-              src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/familly_10373dd34c.svg"
+              src="/_static/cms/familly_10373dd34c.svg"
               alt=""
               width={40}
               height={40}

--- a/apps/site/src/components/results/groups/Groups.tsx
+++ b/apps/site/src/components/results/groups/Groups.tsx
@@ -46,7 +46,7 @@ export default function Groups({ groups }: Props) {
               }
               color="secondary"
               imageAlt=""
-              imageSrc="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_people_raising_arm_fe915601cd.png"
+              imageSrc="/_static/cms/medium_people_raising_arm_fe915601cd.png"
               icon={<PlusIcon className="stroke-primary-700 min-w-8" />}
               ctaClassName="min-w-64"
             />

--- a/apps/site/src/components/results/waterFootprint/_components/WaterActions.tsx
+++ b/apps/site/src/components/results/waterFootprint/_components/WaterActions.tsx
@@ -50,7 +50,7 @@ export default async function WaterActions({ locale }: Props) {
             className="border-primary-50 hover:bg-primary-100 relative flex flex-1 flex-col justify-between overflow-hidden rounded-xl border-2 bg-gray-100 pb-4 no-underline lg:p-4">
             <div>
               <Image
-                src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_priscilla_du_preez_9d7a6e02a2.jpg"
+                src="/_static/cms/medium_priscilla_du_preez_9d7a6e02a2.jpg"
                 width="400"
                 height="200"
                 className="mx-auto mb-3 h-24 w-full object-cover lg:h-36"
@@ -86,7 +86,7 @@ export default async function WaterActions({ locale }: Props) {
             className="border-primary-50 hover:bg-primary-100 relative flex flex-1 flex-col justify-between overflow-hidden rounded-xl border-2 bg-gray-100 pb-4 no-underline lg:p-4">
             <div>
               <Image
-                src="https://s3.fr-par.scw.cloud/nosgestesclimat-prod/cms/medium_lumin_osity_arrosage_champ_eeafa85606.jpg"
+                src="/_static/cms/medium_lumin_osity_arrosage_champ_eeafa85606.jpg"
                 width="400"
                 height="200"
                 className="mx-auto mb-3 h-24 w-full object-cover lg:h-36"

--- a/apps/site/src/design-system/cms/ArticleList.stories.tsx
+++ b/apps/site/src/design-system/cms/ArticleList.stories.tsx
@@ -27,7 +27,7 @@ const mockArticles = [
       htmlTitle: 'Écologie',
     },
     image: {
-      url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      url: '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
       alternativeText: 'Image écologie',
     },
   },
@@ -52,7 +52,7 @@ const mockArticles = [
       htmlTitle: 'Énergie',
     },
     image: {
-      url: 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      url: '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
       alternativeText: 'Image énergie',
     },
   },

--- a/apps/site/src/design-system/cms/ImageWithCategory.stories.tsx
+++ b/apps/site/src/design-system/cms/ImageWithCategory.stories.tsx
@@ -51,7 +51,7 @@ type Story = StoryObj<typeof ImageWithCategory>
 export const Default: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     imageAlt: 'Example image',
     category: 'Écologie',
   },
@@ -60,7 +60,7 @@ export const Default: Story = {
 export const LargeImage: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     imageAlt: 'Large example image',
     width: 640,
     height: 480,
@@ -71,7 +71,7 @@ export const LargeImage: Story = {
 export const WithCustomClasses: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     imageAlt: 'Custom styled image',
     imageClassName: 'border-4 border-blue-500',
     containerClassName: 'p-4 bg-gray-100 rounded-lg',
@@ -82,7 +82,7 @@ export const WithCustomClasses: Story = {
 export const BadgeAlwaysVisible: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     imageAlt: 'Image with always visible badge',
     category: 'Urgent',
     hideBadgeOnMobile: false,
@@ -92,7 +92,7 @@ export const BadgeAlwaysVisible: Story = {
 export const LongCategoryText: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     imageAlt: 'Image with long category',
     category: 'Développement durable et écologie',
   },

--- a/apps/site/src/design-system/cms/MainArticle.stories.tsx
+++ b/apps/site/src/design-system/cms/MainArticle.stories.tsx
@@ -44,7 +44,7 @@ type Story = StoryObj<typeof MainArticle>
 export const Default: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     title: 'Comment réduire son empreinte carbone au quotidien',
     description:
       "<p>Découvrez des gestes simples et efficaces pour réduire votre impact environnemental. Cet article vous guide à travers les actions les plus impactantes que vous pouvez mettre en place dès aujourd'hui.</p>",
@@ -57,7 +57,7 @@ export const Default: Story = {
 export const LongTitle: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     title:
       "Un titre très long qui pourrait déborder sur plusieurs lignes pour tester l'affichage responsive de l'article principal",
     description:
@@ -71,7 +71,7 @@ export const LongTitle: Story = {
 export const LongDescription: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     title: 'Les énergies renouvelables en France',
     description:
       "<p>La France fait face à un défi majeur : la transition énergétique. Cet article explore les différentes sources d'énergies renouvelables disponibles dans notre pays, leur potentiel de développement et les défis à relever pour atteindre nos objectifs climatiques.</p><p>Nous analysons également les politiques publiques mises en place et les investissements nécessaires pour accélérer cette transition.</p>",
@@ -84,7 +84,7 @@ export const LongDescription: Story = {
 export const English: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     title: 'How to reduce your carbon footprint daily',
     description:
       '<p>Discover simple and effective gestures to reduce your environmental impact. This article guides you through the most impactful actions you can implement starting today.</p>',
@@ -97,7 +97,7 @@ export const English: Story = {
 export const ShortContent: Story = {
   args: {
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     title: 'Titre court',
     description: '<p>Description courte.</p>',
     category: 'Innovation',

--- a/apps/site/src/design-system/cms/PostThumbnail.stories.tsx
+++ b/apps/site/src/design-system/cms/PostThumbnail.stories.tsx
@@ -45,7 +45,7 @@ export const Default: Story = {
     title: 'Comment réduire son empreinte carbone au quotidien',
     category: 'Écologie',
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     href: '/blog/article-1',
     trackingEvent: ['blog', 'click', 'article-1'],
   },
@@ -57,7 +57,7 @@ export const LongTitle: Story = {
       "Un titre très long qui pourrait déborder sur plusieurs lignes pour tester l'affichage",
     category: 'Développement durable',
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     href: '/blog/article-2',
     trackingEvent: ['blog', 'click', 'article-2'],
   },
@@ -68,7 +68,7 @@ export const ShortTitle: Story = {
     title: 'Titre court',
     category: 'Technologie',
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     href: '/blog/article-3',
     trackingEvent: ['blog', 'click', 'article-3'],
   },
@@ -79,7 +79,7 @@ export const WithoutTracking: Story = {
     title: 'Article sans tracking',
     category: 'Innovation',
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     href: '/blog/article-4',
     trackingEvent: [],
   },
@@ -90,7 +90,7 @@ export const CustomStyling: Story = {
     title: 'Article avec style personnalisé',
     category: 'Économie',
     imageSrc:
-      'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
+      '/_static/cms/ella_olsson_KP_Db_Ry_FO_Tn_E_unsplash_9b029eb7e6.jpg',
     href: '/blog/article-5',
     trackingEvent: ['blog', 'click', 'article-5'],
     className: 'border-2 border-blue-500',

--- a/apps/site/src/helpers/metadata/getMetadataObject.ts
+++ b/apps/site/src/helpers/metadata/getMetadataObject.ts
@@ -151,9 +151,7 @@ export function getMetadataObject({
       description,
       url,
       type: 'website',
-      images: image
-        ? image
-        : 'https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/metadata_1749c11cdc.png',
+      images: image ? image : '/_static/cms/metadata_1749c11cdc.png',
     },
     alternates: definitiveAlternates,
     ...props,

--- a/apps/site/src/locales/nouveautes/en/admundsen.mdx
+++ b/apps/site/src/locales/nouveautes/en/admundsen.mdx
@@ -20,7 +20,7 @@ In detail, we've given the design a facelift, particularly on :
 
 - A new, more engaging and clearer home page
 
-![new home page](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/landing_page_27acb9a1e7.png)
+![new home page](/_static/cms/landing_page_27acb9a1e7.png)
 
 - Two new landing pages dedicated to our carbon and water footprints
 - And we've got a new tool for writing blog posts: Strapi

--- a/apps/site/src/locales/nouveautes/en/corona.mdx
+++ b/apps/site/src/locales/nouveautes/en/corona.mdx
@@ -8,7 +8,7 @@ image: https://github.com/incubateur-ademe/nosgestesclimat-app/assets/144152881/
 
 What's new in March 2024
 
-![Corona glacier](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/corona_9ec4eda09d.jpg)
+![Corona glacier](/_static/cms/corona_9ec4eda09d.jpg)
 
 > Plastic to protect nature? Contradictory? And yet that's exactly what's happening in Venezuela, which is trying to protect its last glacier at all costs.
 > 2 Hectares. That's what's left of the last glacier in the Andean country, after the disappearance of the other five in recent decades.

--- a/apps/site/src/locales/nouveautes/en/mertz.mdx
+++ b/apps/site/src/locales/nouveautes/en/mertz.mdx
@@ -32,5 +32,5 @@ image: https://upload.wikimedia.org/wikipedia/commons/d/d9/GlacierMertz.JPG
 - Major upgrade of Publicodes (from 1.4.0 to 1.8.2), to boost performance and incorporate the latest features.
 - Significant improvements to the textile education package to raise awareness with new questions and actions!
 
-![capture of the new version of the textile question](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/screenshot_textile_6d6ed51b98.png)
-![capture of the new version of the textile question allowing details to be entered](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/screenshot_textile_2_56066cbd3f.png)
+![capture of the new version of the textile question](/_static/cms/screenshot_textile_6d6ed51b98.png)
+![capture of the new version of the textile question allowing details to be entered](/_static/cms/screenshot_textile_2_56066cbd3f.png)

--- a/apps/site/src/locales/nouveautes/en/shackleton.mdx
+++ b/apps/site/src/locales/nouveautes/en/shackleton.mdx
@@ -20,7 +20,7 @@ image: https://upload.wikimedia.org/wikipedia/commons/6/6e/C84165s1_Ant.Map_Shac
 
 - The _Partners_ page has been revamped and updated
 
-![new partner page](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/relays_2738d796fa.png)
+![new partner page](/_static/cms/relays_2738d796fa.png)
 
 - Translations adjusted and typos corrected
 - Addition of a com banner managed via Strapi: this little homemade tool will enable us to warn you of news or important information, such as World Water Day for example!
@@ -32,7 +32,7 @@ To prepare for the renewed Accessibility audit, we've made a whole host of optim
 - Keyboard-accessible carousel on the home page
 - Multiple accessibility improvements: keyboard navigation, titles, ARIA labels (preview of the Wave tool used for the internal audit stage)
 
-![Accessibility improvements](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/accessibility_6220b87f58.png)
+![Accessibility improvements](/_static/cms/accessibility_6220b87f58.png)
 
 And also :
 

--- a/apps/site/src/locales/nouveautes/en/totten.mdx
+++ b/apps/site/src/locales/nouveautes/en/totten.mdx
@@ -18,7 +18,7 @@ image: https://upload.wikimedia.org/wikipedia/commons/2/22/Knox%2C_Budd_and_Sabr
 
 - Greater emphasis on the water footprint throughout the test: we announced its release here https://nosgestesclimat.fr/nouveautes/thwaites, the water footprint is now available in the test, but we still had to give it its rightful place in the path and the results page _Screenshot_
 
-![better integration of the water footprint](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/water_footprint_d288432ed8.png)
+![better integration of the water footprint](/_static/cms/water_footprint_d288432ed8.png)
 
 - Improved display and tracking iframes
 - Customised questions activated by default

--- a/apps/site/src/locales/nouveautes/en/tre-la-tete.mdx
+++ b/apps/site/src/locales/nouveautes/en/tre-la-tete.mdx
@@ -16,7 +16,7 @@ date: 2022-09-26T17:15:37Z
 
 You won't have missed it, Nos Gestes Climat has a new logo 🥳.
 
-![](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png)
+![](/_static/cms/petit_logo_006dd01955.png)
 
 Frequently mentioned in the press, it will go even less unnoticed.
 

--- a/apps/site/src/locales/nouveautes/fr/Snaefellsjokull.mdx
+++ b/apps/site/src/locales/nouveautes/fr/Snaefellsjokull.mdx
@@ -1,7 +1,7 @@
 ---
 title: Snæfellsjökull, le glacier présidentiable
 date: 2024-06-30T16:50:31Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Snaefellsjoekull_in_the_Morning_7622876302_b771d1c022.jpg
+image: /_static/cms/Snaefellsjoekull_in_the_Morning_7622876302_b771d1c022.jpg
 ---
 
 # Snæfellsjökull, le glacier présidentiable
@@ -11,7 +11,7 @@ Les nouveautés des mois de juin 2024
 <img
   style="width: 400px;"
   alt-text="Snæfellsjökull-le-glacier-présidentiable"
-  src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Snaefellsjoekull_in_the_Morning_7622876302_b771d1c022.jpg"
+  src="/_static/cms/Snaefellsjoekull_in_the_Morning_7622876302_b771d1c022.jpg"
 />
 
 > 🇮🇸 Pour être candidat aux élections présidentielles islandaises, il faut avoir au moins 35 ans et ne pas avoir de casier judiciaire. Pourquoi pas alors le glacier Snæfellsjökull ? Un groupe d’activistes islandais a tenté pendant plusieurs mois de lancer ce nouveau candidat sur la piste présidentielle, pour assurer une plus grande visibilité des sujets d’écologie dans la campagne.

--- a/apps/site/src/locales/nouveautes/fr/admundsen.mdx
+++ b/apps/site/src/locales/nouveautes/fr/admundsen.mdx
@@ -1,10 +1,10 @@
 ---
 title: Admundsend
 date: 2025-01-25T10:21:20Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/admundsen_605c0c9b3c.jpg
+image: /_static/cms/admundsen_605c0c9b3c.jpg
 ---
 
-![Glacier Admundsen](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/admundsen_605c0c9b3c.jpg)
+![Glacier Admundsen](/_static/cms/admundsen_605c0c9b3c.jpg)
 
 💧 Le glacier Amundsen, long de 128 km, est l'un des plus imposants de l'Antarctique. Pour protéger ce géant en péril, des projets innovants comme l'installation de rideaux sous-marins pour ralentir la fonte, sont à l'étude pour atténuer les impacts de cette fonte sur l'élévation du niveau des mers.
 
@@ -20,7 +20,7 @@ En détail, nous avons apporté un coup de frais sur le design notamment sur :
 
 - Une nouvelle page d’accueil plus engageante et plus claire
 
-![Nouvelle page d'accueil](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/medium_landing_page_27acb9a1e7.png)
+![Nouvelle page d'accueil](/_static/cms/medium_landing_page_27acb9a1e7.png)
 
 - Deux landing pages dédiées à l’empreinte carbone et eau voient le jour
 - Et nous avons un nouvel outil pour rédiger les articles de blog : Strapi

--- a/apps/site/src/locales/nouveautes/fr/aletsch.mdx
+++ b/apps/site/src/locales/nouveautes/fr/aletsch.mdx
@@ -1,10 +1,10 @@
 ---
 title: Aletsch
 date: 2023-03-01T17:21:37Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Aletschgletscher_Eggishorn_2e0aea2c96.jpg
+image: /_static/cms/Aletschgletscher_Eggishorn_2e0aea2c96.jpg
 ---
 
-![Glacier d'Aletsch](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Aletschgletscher_Eggishorn_2e0aea2c96.jpg)
+![Glacier d'Aletsch](/_static/cms/Aletschgletscher_Eggishorn_2e0aea2c96.jpg)
 
 > Le [glacier d'Aletsch](https://fr.wikipedia.org/wiki/Glacier_d%27Aletsch) est le plus grand glacier des Alpes, situé dans le sud de la Suisse dans le canton du Valais. ➡️ [Reportage France Info](https://www.francetvinfo.fr/meteo/climat/climat-la-fonte-du-glacier-d-aletsch-revele-ses-secrets-enfouis_5393890.html).
 > Clin d’œil à la Suisse qui a motivé le travail sur la régionalisation du calcul de Nos Gestes Climat.

--- a/apps/site/src/locales/nouveautes/fr/arcouzan.mdx
+++ b/apps/site/src/locales/nouveautes/fr/arcouzan.mdx
@@ -1,10 +1,10 @@
 ---
 title: Arcouzan
 date: 2023-10-09T10:07:31Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Col_de_Pause_Ariege_795cea817b.jpg
+image: /_static/cms/Col_de_Pause_Ariege_795cea817b.jpg
 ---
 
-![Glacier d'Arcouzan](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Col_de_Pause_Ariege_795cea817b.jpg)
+![Glacier d'Arcouzan](/_static/cms/Col_de_Pause_Ariege_795cea817b.jpg)
 
 > Seul glacier du département de l'Ariège, le glacier d'Arcouzan (ou glacier du Mont Valier) est un petit glacier de cirque des Pyrénées. Il a fait parler de lui le 2 octobre 2023 suite à [la découverte d'un sac à dos vieux de 40 ans en son sein](https://france3-regions.francetvinfo.fr/occitanie/ariege/foix/decouverte-enigmatique-sur-un-glacier-des-pyrenees-un-sac-a-dos-vieux-de-40-ans-emerge-de-la-glace-2849477.html) !
 

--- a/apps/site/src/locales/nouveautes/fr/argentiere.mdx
+++ b/apps/site/src/locales/nouveautes/fr/argentiere.mdx
@@ -1,10 +1,10 @@
 ---
 title: Argentière
 date: 2020-10-19T08:28:40Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/800px_Galcier_Argentiere7479_084adfc843.JPG
+image: /_static/cms/800px_Galcier_Argentiere7479_084adfc843.JPG
 ---
 
-![Glacier d'Argentière](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/800px_Galcier_Argentiere7479_084adfc843.JPG)
+![Glacier d'Argentière](/_static/cms/800px_Galcier_Argentiere7479_084adfc843.JPG)
 
 > En bref : introduction des fiches actions et d'un meilleur modèle de la voiture
 

--- a/apps/site/src/locales/nouveautes/fr/asterix.mdx
+++ b/apps/site/src/locales/nouveautes/fr/asterix.mdx
@@ -1,10 +1,10 @@
 ---
 title: ASTERiX
 date: 2021-06-14T15:14:47Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/121914885_f8bb1080_cd32_11eb_898b_fa39bae7a331_7f43ae1763.jpeg
+image: /_static/cms/121914885_f8bb1080_cd32_11eb_898b_fa39bae7a331_7f43ae1763.jpeg
 ---
 
-![image](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/121914885_f8bb1080_cd32_11eb_898b_fa39bae7a331_7f43ae1763.jpeg)
+![image](/_static/cms/121914885_f8bb1080_cd32_11eb_898b_fa39bae7a331_7f43ae1763.jpeg)
 
 *https://mobile.twitter.com/EtienneBerthie2/status/1387426262306656265*
 

--- a/apps/site/src/locales/nouveautes/fr/bossons.mdx
+++ b/apps/site/src/locales/nouveautes/fr/bossons.mdx
@@ -1,10 +1,10 @@
 ---
 title: Bossons
 date: 2020-09-01T15:10:55Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Absolute_Mt_Blanc_01_c05b85e610.jpg
+image: /_static/cms/Absolute_Mt_Blanc_01_c05b85e610.jpg
 ---
 
-![](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Absolute_Mt_Blanc_01_c05b85e610.jpg)
+![](/_static/cms/Absolute_Mt_Blanc_01_c05b85e610.jpg)
 
 > En bref : Alimentation, empreinte moyenne et quelques bugs
 

--- a/apps/site/src/locales/nouveautes/fr/corona.mdx
+++ b/apps/site/src/locales/nouveautes/fr/corona.mdx
@@ -1,14 +1,14 @@
 ---
 title: Le Corona
 date: 2024-03-27T16:50:31Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/317308737_f4f98ff5_df01_4b67_abe0_22bc051aa6a9_fc407b0f45.jpeg
+image: /_static/cms/317308737_f4f98ff5_df01_4b67_abe0_22bc051aa6a9_fc407b0f45.jpeg
 ---
 
 # Le Corona
 
 Les nouveautés des mois de mars 2024
 
-![Glacier corona](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/corona_9ec4eda09d.jpg)
+![Glacier corona](/_static/cms/corona_9ec4eda09d.jpg)
 
 > 🥤 Du plastique pour protéger la nature ? Contradictoire ? Et pourtant, c'est bien ce qu'il se passe au Venezuela qui tente de protéger coûte que coûte son dernier glacier.
 > 2 Hectares. C'est ce qu'il reste du tout dernier glacier du pays andin, après la disparition des cinq autres dans les dernières décennies.

--- a/apps/site/src/locales/nouveautes/fr/deux-alpes.mdx
+++ b/apps/site/src/locales/nouveautes/fr/deux-alpes.mdx
@@ -1,10 +1,10 @@
 ---
 title: Deux alpes
 date: 2022-07-22T20:02:56Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Jeu_de_lumiere_aux_deux_alpes_02_518c8320dd.JPG
+image: /_static/cms/Jeu_de_lumiere_aux_deux_alpes_02_518c8320dd.JPG
 ---
 
-![Glacier des Gabiétous](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Jeu_de_lumiere_aux_deux_alpes_02_518c8320dd.JPG)
+![Glacier des Gabiétous](/_static/cms/Jeu_de_lumiere_aux_deux_alpes_02_518c8320dd.JPG)
 
 > Le [glacier des deux alpes](https://fr.wikipedia.org/wiki/Les_Deux_Alpes) est fermé précocement cette année
 

--- a/apps/site/src/locales/nouveautes/fr/etendard.mdx
+++ b/apps/site/src/locales/nouveautes/fr/etendard.mdx
@@ -1,13 +1,13 @@
 ---
 title: Étendard
 date: 2020-08-07T08:01:26Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/234638906_f11583de_25d7_48cd_a8c8_ecd3abc5f7c5_7c26c0acc0.JPG
+image: /_static/cms/234638906_f11583de_25d7_48cd_a8c8_ecd3abc5f7c5_7c26c0acc0.JPG
 ---
 
 > En bref :
 > 🚀 C'est la 1ère version beta de Nos Gestes Climat, sorti en Juin 2020.
 
-![Refuge_et_Pic_de_l'Étendard_Savoie](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/234638906_f11583de_25d7_48cd_a8c8_ecd3abc5f7c5_7c26c0acc0.JPG)
+![Refuge_et_Pic_de_l'Étendard_Savoie](/_static/cms/234638906_f11583de_25d7_48cd_a8c8_ecd3abc5f7c5_7c26c0acc0.JPG)
 
 C'est essentiellement une reprise du modèle 2.6 de l'outil MicMac d'Avenir Climatique, qui résidait dans un fichier tableur à télécharger.
 MicMac Web n'était plus mis à jour, il fallait lancer une nouvelle version de l'interface, plus moderne, intéractive, facile à faire évoluer et faisant transparence totale sur les calculs.

--- a/apps/site/src/locales/nouveautes/fr/gabietous-gavarnie.mdx
+++ b/apps/site/src/locales/nouveautes/fr/gabietous-gavarnie.mdx
@@ -1,10 +1,10 @@
 ---
 title: Gabiétous (Gavarnie)
 date: 2022-06-28T10:44:54Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_Gavarnie_recti_small_Wikimedia_Commons_982b256271.jpg
+image: /_static/cms/640px_Gavarnie_recti_small_Wikimedia_Commons_982b256271.jpg
 ---
 
-![Glacier des Gabiétous](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_Gavarnie_recti_small_Wikimedia_Commons_982b256271.jpg)
+![Glacier des Gabiétous](/_static/cms/640px_Gavarnie_recti_small_Wikimedia_Commons_982b256271.jpg)
 
 > En bref :
 >

--- a/apps/site/src/locales/nouveautes/fr/gebroulaz.mdx
+++ b/apps/site/src/locales/nouveautes/fr/gebroulaz.mdx
@@ -1,10 +1,10 @@
 ---
 title: Gébroulaz
 date: 2022-06-08T16:30:50Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_de_Gebroulaz2_2494893645.jpg
+image: /_static/cms/Glacier_de_Gebroulaz2_2494893645.jpg
 ---
 
-![Glacier de Gébroulaz](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_de_Gebroulaz2_2494893645.jpg)
+![Glacier de Gébroulaz](/_static/cms/Glacier_de_Gebroulaz2_2494893645.jpg)
 
 > En bref :
 >

--- a/apps/site/src/locales/nouveautes/fr/glacier-blanc.mdx
+++ b/apps/site/src/locales/nouveautes/fr/glacier-blanc.mdx
@@ -1,10 +1,10 @@
 ---
 title: Glacier blanc
 date: 2021-03-22T11:23:27Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/800px_Wikiecrins_3a17a29a32.jpg
+image: /_static/cms/800px_Wikiecrins_3a17a29a32.jpg
 ---
 
-![Glacier Blanc](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/800px_Wikiecrins_3a17a29a32.jpg)
+![Glacier Blanc](/_static/cms/800px_Wikiecrins_3a17a29a32.jpg)
 
 Nous avons complètement revu la sélection du matériel numérique. Ça s'est fait [ici](https://github.com/incubateur-ademe/nosgestesclimat/pull/905).
 

--- a/apps/site/src/locales/nouveautes/fr/glacier-du-geant.mdx
+++ b/apps/site/src/locales/nouveautes/fr/glacier-du-geant.mdx
@@ -1,10 +1,10 @@
 ---
 title: Glacier du Géant
 date: 2022-11-10T09:25:32Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Aerial_view_of_Glacier_du_Geant_0f3102c196.jpg
+image: /_static/cms/Aerial_view_of_Glacier_du_Geant_0f3102c196.jpg
 ---
 
-![](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Aerial_view_of_Glacier_du_Geant_0f3102c196.jpg)
+![](/_static/cms/Aerial_view_of_Glacier_du_Geant_0f3102c196.jpg)
 
 > En image, le [Glacier du Géant](https://fr.wikipedia.org/wiki/Glacier_du_G%C3%A9ant)
 

--- a/apps/site/src/locales/nouveautes/fr/grands-couloirs.mdx
+++ b/apps/site/src/locales/nouveautes/fr/grands-couloirs.mdx
@@ -1,10 +1,10 @@
 ---
 title: Grands Couloirs
 date: 2021-02-08T14:50:44Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_Glacier_de_la_Grande_Casse_le_13_aout_2016_55c22a12ef.JPG
+image: /_static/cms/640px_Glacier_de_la_Grande_Casse_le_13_aout_2016_55c22a12ef.JPG
 ---
 
-![Glacier des Grands Couloirs](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_Glacier_de_la_Grande_Casse_le_13_aout_2016_55c22a12ef.JPG)]
+![Glacier des Grands Couloirs](/_static/cms/640px_Glacier_de_la_Grande_Casse_le_13_aout_2016_55c22a12ef.JPG)]
 
 > En bref : on écoute chacun de vos retours, et l'amélioration continue 🔄
 

--- a/apps/site/src/locales/nouveautes/fr/guadeloupe.mdx
+++ b/apps/site/src/locales/nouveautes/fr/guadeloupe.mdx
@@ -1,10 +1,10 @@
 ---
 title: Guadeloupe
 date: 2022-10-04T08:17:41Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Guadeloupe_from_ISS_f6c2faca1f.jpg
+image: /_static/cms/Guadeloupe_from_ISS_f6c2faca1f.jpg
 ---
 
-![](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Guadeloupe_from_ISS_f6c2faca1f.jpg)
+![](/_static/cms/Guadeloupe_from_ISS_f6c2faca1f.jpg)
 
 > L'île de la [Guadeloupe](https://fr.wikipedia.org/wiki/Guadeloupe)
 
@@ -24,7 +24,7 @@ Ce travail essentiel qu'on avait pour l'instant mis de côté a été motivé pa
   <img
     width="800"
     alt="screenshot"
-    src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/user_screenshot_7d3f850a0d.png"
+    src="/_static/cms/user_screenshot_7d3f850a0d.png"
   />
 </p>
 

--- a/apps/site/src/locales/nouveautes/fr/la-chiaupe.mdx
+++ b/apps/site/src/locales/nouveautes/fr/la-chiaupe.mdx
@@ -1,14 +1,14 @@
 ---
 title: La Chiaupe
 date: 2023-12-20T16:50:31Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Sommet_de_Bellecote_3417_m_some_3_8_km_East_of_Roche_de_Mio_2739_m_panoramio_ed6b4646b6.jpg
+image: /_static/cms/Sommet_de_Bellecote_3417_m_some_3_8_km_East_of_Roche_de_Mio_2739_m_panoramio_ed6b4646b6.jpg
 ---
 
 #Le Glacier de la Chiaupe
 
 Les nouveautés du mois de décembre 2023
 
-![Glacier de la Chiaupe](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Sommet_de_Bellecote_3417_m_some_3_8_km_East_of_Roche_de_Mio_2739_m_panoramio_ed6b4646b6.jpg)
+![Glacier de la Chiaupe](/_static/cms/Sommet_de_Bellecote_3417_m_some_3_8_km_East_of_Roche_de_Mio_2739_m_panoramio_ed6b4646b6.jpg)
 
 > 🎿 Ca y est : c’est le dernier hiver où les skieurs pourront tirer parti des infrastructures placées en partie sur le glacier de la Chiaupe, dans les hauteurs de la Plagne. Suite à une fonte accélérée du glacier dans la dernière décennie, la décision a été prise il y a maintenant 3 ans de démanteler les infrastructures sur la hauteur de la station, pour les descendre de 200m en contrebas.
 >

--- a/apps/site/src/locales/nouveautes/fr/las-neous.mdx
+++ b/apps/site/src/locales/nouveautes/fr/las-neous.mdx
@@ -1,10 +1,10 @@
 ---
 title: Las Néous
 date: 2022-01-31T18:39:37Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_de_Las_Neous_8_aout_1905_f55a070497.png
+image: /_static/cms/Glacier_de_Las_Neous_8_aout_1905_f55a070497.png
 ---
 
-![Glacier de las Néous](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_de_Las_Neous_8_aout_1905_f55a070497.png)
+![Glacier de las Néous](/_static/cms/Glacier_de_Las_Neous_8_aout_1905_f55a070497.png)
 
 > En bref :
 >

--- a/apps/site/src/locales/nouveautes/fr/le-sang-des-glaciers.mdx
+++ b/apps/site/src/locales/nouveautes/fr/le-sang-des-glaciers.mdx
@@ -1,10 +1,10 @@
 ---
 title: Le sang des glaciers
 date: 2023-06-27T15:12:14Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_170828_FS_Inyo_PRW_001_Mount_Ritter_36217539154_cf49b97237.jpg
+image: /_static/cms/640px_170828_FS_Inyo_PRW_001_Mount_Ritter_36217539154_cf49b97237.jpg
 ---
 
-![Neige Rouge sur le mont Ritter - Etats-Unis](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_170828_FS_Inyo_PRW_001_Mount_Ritter_36217539154_cf49b97237.jpg)
+![Neige Rouge sur le mont Ritter - Etats-Unis](/_static/cms/640px_170828_FS_Inyo_PRW_001_Mount_Ritter_36217539154_cf49b97237.jpg)
 
 > Au printemps, les algues rouges (Sanguina) qui circulent à la surface des cristaux de neige prolifèrent en captant du CO2 et couvrent la neige d'un rouge couleur sang. Cette coloration diminue l'albédo de la neige, accélère donc la fonte du manteau neigeux concerné, ce qui raccourcit la durée de cet enneigement. Ce phénomène semble de plus en plus fréquent et correlé au réchauffement climatique. Pour les plus curieux, le [reportage France Info du 30 mai 2023](https://www.francetvinfo.fr/monde/environnement/environnement-la-neige-rouge-de-plus-en-plus-presente-sur-les-glaciers-du-monde_5857430.html) peut vous intéresser !
 

--- a/apps/site/src/locales/nouveautes/fr/le-tour.mdx
+++ b/apps/site/src/locales/nouveautes/fr/le-tour.mdx
@@ -1,10 +1,10 @@
 ---
 title: Le Tour
 date: 2021-08-24T07:02:28Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_du_Tour_2021_b4376fb87a.jpg
+image: /_static/cms/Glacier_du_Tour_2021_b4376fb87a.jpg
 ---
 
-![Glacier du Tour](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_du_Tour_2021_b4376fb87a.jpg)
+![Glacier du Tour](/_static/cms/Glacier_du_Tour_2021_b4376fb87a.jpg)
 
 _Le Glacier du Tour se trouve dans la vallée de Chamonix, une vallée accessible grâce à un superbe TER de montagne_
 

--- a/apps/site/src/locales/nouveautes/fr/lempreinte-climat-des-services-societaux.mdx
+++ b/apps/site/src/locales/nouveautes/fr/lempreinte-climat-des-services-societaux.mdx
@@ -1,10 +1,10 @@
 ---
 title: L'empreinte climat des "services sociétaux"
 date: 2022-12-14T10:49:38Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/205978955_88a0ad61_244c_4afb_89a9_600eef3a5f1c_b7973c2348.jpg
+image: /_static/cms/205978955_88a0ad61_244c_4afb_89a9_600eef3a5f1c_b7973c2348.jpg
 ---
 
-![C'est à l'assemblée nationale dans le 7ème arrondissement de Paris qu'est voté chaque année le budget de l'État](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/205978955_88a0ad61_244c_4afb_89a9_600eef3a5f1c_b7973c2348.jpg)
+![C'est à l'assemblée nationale dans le 7ème arrondissement de Paris qu'est voté chaque année le budget de l'État](/_static/cms/205978955_88a0ad61_244c_4afb_89a9_600eef3a5f1c_b7973c2348.jpg)
 
 Si vous avez déjà fait un test d'empreinte carbone, vous aurez peut-être remarqué une catégorie assez étonnante : les services publics. Environ 1 tonne sur les 10 tonnes de CO₂ₑ de moyenne française en ordre de grandeur, cela peut sembler peu... Seulement, pour ceux et celles qui adoptent un mode de vie plutôt bas carbone, et plus généralement par rapport à l'objectif de 2 tonnes d'empreinte individuelle (rappelons que l'important n'est pas l'objectif mais le [scénario de transition](https://nosgestesclimat.fr/blog/environnement/budget), 1 tonne peut légitimement ressembler à un éléphant dans la pièce !
 

--- a/apps/site/src/locales/nouveautes/fr/marinet.mdx
+++ b/apps/site/src/locales/nouveautes/fr/marinet.mdx
@@ -1,10 +1,10 @@
 ---
 title: Marinet
 date: 2021-02-20T07:11:24Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Chambeyron_lac_du_marinet_16006836cf.jpg
+image: /_static/cms/Chambeyron_lac_du_marinet_16006836cf.jpg
 ---
 
-![Aiguille de Chambeyron](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Chambeyron_lac_du_marinet_16006836cf.jpg)
+![Aiguille de Chambeyron](/_static/cms/Chambeyron_lac_du_marinet_16006836cf.jpg)
 
 Dans cette version, de belles améliorations pour la 🚗 et la 🏍, entre autres !
 

--- a/apps/site/src/locales/nouveautes/fr/mer-de-glace.mdx
+++ b/apps/site/src/locales/nouveautes/fr/mer-de-glace.mdx
@@ -1,10 +1,10 @@
 ---
 title: Mer de Glace
 date: 2021-03-30T13:35:41Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Merdeglace_8a6d60f601.jpg
+image: /_static/cms/Merdeglace_8a6d60f601.jpg
 ---
 
-![Mer de Glace](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Merdeglace_8a6d60f601.jpg)
+![Mer de Glace](/_static/cms/Merdeglace_8a6d60f601.jpg)
 
 ## Nos Gestes Climat, la v1
 

--- a/apps/site/src/locales/nouveautes/fr/mertz.mdx
+++ b/apps/site/src/locales/nouveautes/fr/mertz.mdx
@@ -1,10 +1,10 @@
 ---
 title: Mertz
 date: 2025-05-25T10:21:20Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_Mertz_1a11d5cb31.JPG
+image: /_static/cms/Glacier_Mertz_1a11d5cb31.JPG
 ---
 
-![Glacier Mertz](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_Mertz_1a11d5cb31.JPG)
+![Glacier Mertz](/_static/cms/Glacier_Mertz_1a11d5cb31.JPG)
 
 💧 Le **glacier Mertz** se distingue avec sa spectaculaire langue de glace qui s’étire jusque dans l’océan Austral. Il a même “perdu un bout” en 2010, formant un iceberg titanesque ! Ces colosses de glace sont les sentinelles silencieuses de notre planète… et ils nous rappellent que chaque action compte pour préserver leur beauté 💙
 
@@ -32,5 +32,5 @@ image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glacier_Mertz_1a11d5
 - Upgrade majeur de Publicodes (de 1.4.0 à 1.8.2), pour booster les performances et intégrer les dernières fonctionnalités .
 - Amélioration significative de la pédagogie autour du textile pour mieux sensibiliser avec des nouvelles questions et des actions !
 
-![Capture de la nouvelle version de la question textile](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/screenshot_textile_6d6ed51b98.png)
-![Capture de la nouvelle version de la question textile permettant de renseigner les détails](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/screenshot_textile_2_56066cbd3f.png)
+![Capture de la nouvelle version de la question textile](/_static/cms/screenshot_textile_6d6ed51b98.png)
+![Capture de la nouvelle version de la question textile permettant de renseigner les détails](/_static/cms/screenshot_textile_2_56066cbd3f.png)

--- a/apps/site/src/locales/nouveautes/fr/mont-perdu.mdx
+++ b/apps/site/src/locales/nouveautes/fr/mont-perdu.mdx
@@ -1,10 +1,10 @@
 ---
 title: Mont-Perdu
 date: 2021-01-25T10:21:20Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_MONTE_PERDIDO_c2b7abcf10.JPG
+image: /_static/cms/640px_MONTE_PERDIDO_c2b7abcf10.JPG
 ---
 
-![](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_MONTE_PERDIDO_c2b7abcf10.JPG)
+![](/_static/cms/640px_MONTE_PERDIDO_c2b7abcf10.JPG)
 
 > En bref : le moteur de calcul nosgestesclimat.fr a été complètement modernisé
 

--- a/apps/site/src/locales/nouveautes/fr/ossoue.mdx
+++ b/apps/site/src/locales/nouveautes/fr/ossoue.mdx
@@ -1,10 +1,10 @@
 ---
 title: Ossoue
 date: 2020-09-22T12:30:47Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/400px_Pic_Montferrat_551560149d.jpg
+image: /_static/cms/400px_Pic_Montferrat_551560149d.jpg
 ---
 
-![](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/400px_Pic_Montferrat_551560149d.jpg)
+![](/_static/cms/400px_Pic_Montferrat_551560149d.jpg)
 
 > En bref : améliorations des questions sur le transport 🚦
 > ℹ Ceci est une petite version, avec quelques améliorations mais rien de bouleversé. Ce n'est que partie remise.

--- a/apps/site/src/locales/nouveautes/fr/pasterze.mdx
+++ b/apps/site/src/locales/nouveautes/fr/pasterze.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pasterze
 date: 2024-05-30T16:50:31Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/335209920_f53f2521_269e_4d45_81bb_8e0418e04e35_3a1c1f48ad.jpeg
+image: /_static/cms/335209920_f53f2521_269e_4d45_81bb_8e0418e04e35_3a1c1f48ad.jpeg
 ---
 
 # Le Pasterze
@@ -11,7 +11,7 @@ Les nouveautés des mois d'avril et mai 2024
 <img
   style="width: 400px;"
   alt-text="Pasterze-dernier-glacier-autrichien"
-  src="https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/335209920_f53f2521_269e_4d45_81bb_8e0418e04e35_3a1c1f48ad.jpeg"
+  src="/_static/cms/335209920_f53f2521_269e_4d45_81bb_8e0418e04e35_3a1c1f48ad.jpeg"
 />
 
 > 🇦🇹 La fin des glaciers autrichiens ? La symbolique est grande : le Pasterze, dernier glacier autrichien a été métaphoriquement enterré par l’organisation environnementale Protect Our Winters (POW) pour sensibiliser au recul des glaciers.

--- a/apps/site/src/locales/nouveautes/fr/periades.mdx
+++ b/apps/site/src/locales/nouveautes/fr/periades.mdx
@@ -1,10 +1,10 @@
 ---
 title: Périades
 date: 2021-04-27T15:59:46Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/800px_00_Chamonix_Les_Grandes_Jorasses_JPG_05f7dea53a.jpg
+image: /_static/cms/800px_00_Chamonix_Les_Grandes_Jorasses_JPG_05f7dea53a.jpg
 ---
 
-![Glacier des Périades](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/800px_00_Chamonix_Les_Grandes_Jorasses_JPG_05f7dea53a.jpg)
+![Glacier des Périades](/_static/cms/800px_00_Chamonix_Les_Grandes_Jorasses_JPG_05f7dea53a.jpg)
 
 > En résumé :
 >

--- a/apps/site/src/locales/nouveautes/fr/shackleton.mdx
+++ b/apps/site/src/locales/nouveautes/fr/shackleton.mdx
@@ -1,10 +1,10 @@
 ---
 title: Schakleton
 date: 2025-04-25T10:21:20Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/C84165s1_Ant_Map_Shackleton_Glacier_b88461fccd.jpg
+image: /_static/cms/C84165s1_Ant_Map_Shackleton_Glacier_b88461fccd.jpg
 ---
 
-![Glacier Shackelton](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/C84165s1_Ant_Map_Shackleton_Glacier_b88461fccd.jpg)
+![Glacier Shackelton](/_static/cms/C84165s1_Ant_Map_Shackleton_Glacier_b88461fccd.jpg)
 
 💧 Le glacier Shackleton, s'étendant sur près de 96 km à travers la chaîne de la Reine-Maud jusqu'à la barrière de Ross en Antarctique, porte le nom de l'explorateur Ernest Shackleton. Bien que moins médiatisé que d'autres glaciers, il incarne l'histoire des grandes expéditions polaires. Récemment, l'épave de l'Endurance, le navire de Shackleton, a été retrouvée dans un état remarquable !
 
@@ -20,7 +20,7 @@ image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/C84165s1_Ant_Map_Sha
 
 - La page _Partenaires_ a fait peau neuve et a été mise à jour
 
-![Nouvelle page partenaire](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/relays_2738d796fa.png)
+![Nouvelle page partenaire](/_static/cms/relays_2738d796fa.png)
 
 - Traductions ajustées et coquilles corrigées
 - Ajout d’une bannière de com gérée via Strapi : ce petit outil fait maison nous permettra de vous prévenir des nouveautés ou informations importantes, comme la journée mondiale de l'eau par exemple !
@@ -32,7 +32,7 @@ Pour nous préparer au renouvellement de l'audit Accessibilité, nous avons fait
 - Carrousel accessible au clavier sur la page d'accueil
 - Améliorations multiples pour l’accessibilité : navigation clavier, titres, labels ARIA (aperçu de l’outil Wave utilisé pour l’étape d’audit interne)
 
-![Améliorations d'accessibilité](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/accessibility_6220b87f58.png)
+![Améliorations d'accessibilité](/_static/cms/accessibility_6220b87f58.png)
 
 Et aussi :
 

--- a/apps/site/src/locales/nouveautes/fr/svalbard.mdx
+++ b/apps/site/src/locales/nouveautes/fr/svalbard.mdx
@@ -1,14 +1,14 @@
 ---
 title: Le Svalbard
 date: 2024-02-19T16:50:31Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/305166545_db0bec84_5cc2_4123_b990_d434f1234545_9dd98feba6.jpeg
+image: /_static/cms/305166545_db0bec84_5cc2_4123_b990_d434f1234545_9dd98feba6.jpeg
 ---
 
 #Le Svalbard
 
 Les nouveautés des mois de janvier et février 2024
 
-![Le Svalbard](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/305166545_db0bec84_5cc2_4123_b990_d434f1234545_9dd98feba6.jpeg)
+![Le Svalbard](/_static/cms/305166545_db0bec84_5cc2_4123_b990_d434f1234545_9dd98feba6.jpeg)
 
 > Le Svalbard, un archipel norvégien proche du Groënland, au coeur de l'Océan Arctique, est un lieu particulièrement apprécié des glaciologues notamment Heïdi Sevestre, glaciologue française.
 > Dans [cet épisode](https://www.radiofrance.fr/franceculture/podcasts/le-biais-d-heidi-sevestre/voyage-a-l-interieur-d-un-glacier-4570455) de sa chronique hebdomadaire sur France Culture, Heïdi Sevestre nous décrit ses expéditions au coeur de l'un des glaciers de l'archipel : à la fois superbes et terrifiantes, car témoins directs du changement climatique dont les glaciers sont au rang des premières victimes.

--- a/apps/site/src/locales/nouveautes/fr/taconnaz.mdx
+++ b/apps/site/src/locales/nouveautes/fr/taconnaz.mdx
@@ -1,10 +1,10 @@
 ---
 title: Taconnaz
 date: 2021-11-02T11:01:01Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Taconnaz_433165ede9.JPG
+image: /_static/cms/Taconnaz_433165ede9.JPG
 ---
 
-![Glacier de Taconnaz](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Taconnaz_433165ede9.JPG)
+![Glacier de Taconnaz](/_static/cms/Taconnaz_433165ede9.JPG)
 
 > En bref :
 >

--- a/apps/site/src/locales/nouveautes/fr/theodule.mdx
+++ b/apps/site/src/locales/nouveautes/fr/theodule.mdx
@@ -1,7 +1,7 @@
 ---
 title: Théodule
 date: 2023-11-23T16:50:31Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Materhorno_de_Gornergrato_32329eca4f.jpg
+image: /_static/cms/Materhorno_de_Gornergrato_32329eca4f.jpg
 ---
 
 #Le Glacier du Théodule

--- a/apps/site/src/locales/nouveautes/fr/thwaites.mdx
+++ b/apps/site/src/locales/nouveautes/fr/thwaites.mdx
@@ -1,7 +1,7 @@
 ---
 title: Thwaites, le glacier de l'apocalypse
 date: 2024-09-19T16:50:31Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Thwaites_Glacier_86fdc647ed.jpg
+image: /_static/cms/Thwaites_Glacier_86fdc647ed.jpg
 ---
 
 #Thwaites, le glacier de l'apocalypse

--- a/apps/site/src/locales/nouveautes/fr/totten.mdx
+++ b/apps/site/src/locales/nouveautes/fr/totten.mdx
@@ -1,10 +1,10 @@
 ---
 title: Totten
 date: 2025-03-25T10:21:20Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Knox_Budd_and_Sabrina_Coasts_Antarctica_b4a154fb2b.jpg
+image: /_static/cms/Knox_Budd_and_Sabrina_Coasts_Antarctica_b4a154fb2b.jpg
 ---
 
-![Glacier Totten](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Knox_Budd_and_Sabrina_Coasts_Antarctica_b4a154fb2b.jpg)
+![Glacier Totten](/_static/cms/Knox_Budd_and_Sabrina_Coasts_Antarctica_b4a154fb2b.jpg)
 
 💧 Le **glacier Totten**, c’est un mastodonte du sud, l’un des plus grands de l’hémisphère sud, capable à lui seul d’impacter le niveau des océans s’il venait à fondre trop vite — un vrai baromètre du changement climatique 🌡️.
 
@@ -18,7 +18,7 @@ image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Knox_Budd_and_Sabrin
 
 - Meilleure mise en avant de l’empreinte eau dans tout le test : on vous avait annoncé sa sortie ici https://nosgestesclimat.fr/nouveautes/thwaites, l'empreinte eau est maintenant disponible dans le test, mais il nous restait encore à lui donner toute sa place dans le parcours et la page de résultat _Screenshot_
 
-![Meilleure intégration de l'empreinte eau](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/water_footprint_d288432ed8.png)
+![Meilleure intégration de l'empreinte eau](/_static/cms/water_footprint_d288432ed8.png)
 
 - Iframes améliorés côté affichage et suivi
 - Questions personnalisées activées par défaut

--- a/apps/site/src/locales/nouveautes/fr/tre-la-tete.mdx
+++ b/apps/site/src/locales/nouveautes/fr/tre-la-tete.mdx
@@ -1,10 +1,10 @@
 ---
 title: Tré-la-Tête
 date: 2022-09-26T17:15:37Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_Glacier_de_Tre_la_Tete_ea67cdb4dd.jpg
+image: /_static/cms/640px_Glacier_de_Tre_la_Tete_ea67cdb4dd.jpg
 ---
 
-![Glacier de Tré-la-Tête](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_Glacier_de_Tre_la_Tete_ea67cdb4dd.jpg)
+![Glacier de Tré-la-Tête](/_static/cms/640px_Glacier_de_Tre_la_Tete_ea67cdb4dd.jpg)
 
 > Le [glacier de Tré-la-Tête](https://fr.wikipedia.org/wiki/Glacier_de_Tré-la-Tête) est le 4ème plus grand glacier en France. Une 📽️ [vidéo Brut intéressante à son sujet suite à l'été hors normes 2022 (29/07/2022)](https://www.francetvinfo.fr/meteo/canicule/video-un-glaciologue-repond-a-cinq-questions-sur-les-glaciers_5283679.html)
 
@@ -17,7 +17,7 @@ image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/640px_Glacier_de_Tre
 
 Vous ne l'aurez pas manqué, Nos Gestes Climat se pare d'un nouveau logo 🥳.
 
-![](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/petit_logo_006dd01955.png)
+![](/_static/cms/petit_logo_006dd01955.png)
 
 Fréquemment cité dans la presse, il y passera encore moins inaperçu.
 

--- a/apps/site/src/locales/nouveautes/fr/vatnajokull.mdx
+++ b/apps/site/src/locales/nouveautes/fr/vatnajokull.mdx
@@ -1,10 +1,10 @@
 ---
 title: Vatnajökull
 date: 2023-04-26T16:43:04Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Breidamerkurjoekull_0f372cb7be.jpg
+image: /_static/cms/Breidamerkurjoekull_0f372cb7be.jpg
 ---
 
-![Le glacier Vatnajökull](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Breidamerkurjoekull_0f372cb7be.jpg)
+![Le glacier Vatnajökull](/_static/cms/Breidamerkurjoekull_0f372cb7be.jpg)
 
 > Le [Vatnajökull](https://fr.wikipedia.org/wiki/Vatnaj%C3%B6kull) est la plus grande [calotte glaciaire](https://fr.wikipedia.org/wiki/Calotte_glaciaire) d'[Islande](https://fr.wikipedia.org/wiki/Islande). C'est le deuxième [glacier](https://fr.wikipedia.org/wiki/Glacier) le plus volumineux d'[Europe](https://fr.wikipedia.org/wiki/Europe).
 

--- a/apps/site/src/locales/nouveautes/fr/vinciguerra.mdx
+++ b/apps/site/src/locales/nouveautes/fr/vinciguerra.mdx
@@ -1,10 +1,10 @@
 ---
 title: Vinciguerra
 date: 2024-12-25T17:21:37Z
-image: https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glaciar_Vinciguerra_819a1be9e6.jpg
+image: /_static/cms/Glaciar_Vinciguerra_819a1be9e6.jpg
 ---
 
-![Glacier Vinciguerra](https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/Glaciar_Vinciguerra_819a1be9e6.jpg)
+![Glacier Vinciguerra](/_static/cms/Glaciar_Vinciguerra_819a1be9e6.jpg)
 
 💧 Situé à proximité d'Ushuaïa, le glacier Vinciguerra est un trésor naturel de la Terre de Feu. Il offre des paysages époustouflants, notamment la lagune de los Témpanos, parsemée d'icebergs. Classé site Ramsar depuis 2009, ce glacier est un indicateur des effets du changement climatique, ayant perdu environ 50 % de sa surface entre 1970 et 2008.
 

--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -62,6 +62,14 @@ server {
         proxy_cache_lock on;
     }
 
+    location /_static/cms/ {
+        proxy_pass https://nosgestesclimat-prod.s3.fr-par.scw.cloud;
+        proxy_cache_valid 200 365d;
+        proxy_cache_lock on;
+        proxy_hide_header Cache-Control;
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
     location ~ ^/(_next/image|images|misc|fonts)/ {
         proxy_pass https://scalingo;
         proxy_cache_valid 200 30d;


### PR DESCRIPTION
## Why

Les assets servis depuis `nosgestesclimat-prod.s3.fr-par.scw.cloud` n'ont pas de `Cache-Control` approprié (Scaleway Object Storage ne les ajoute pas). Cela oblige le navigateur à les re-télécharger à chaque visite, gaspillant bande passante et temps de chargement.

## What

### Nginx — reverse proxy `/_static/cms/*` → S3

```nginx
location /_static/cms/ {
    proxy_pass https://nosgestesclimat-prod.s3.fr-par.scw.cloud;
    proxy_cache_valid 200 365d;
    proxy_cache_lock on;
    proxy_hide_header Cache-Control;
    add_header Cache-Control "public, max-age=31536000, immutable" always;
}
```

- TTL 1 an avec `immutable` (les assets S3 sont versionnés par hash)
- `proxy_hide_header` supprime le Cache-Control inexistant/incorrect de SCW

### App — remplacement de toutes les URLs S3 hardcodées

`https://nosgestesclimat-prod.s3.fr-par.scw.cloud/cms/...` → `/_static/cms/...`

- 109 fichiers modifiés : JSX/TSX, MDX, webmanifest, metadata
- Les URLs relatives sont résolues par le navigateur via notre domaine → Nginx → S3
- Les images CMS (Strapi) ne sont pas affectées — elles sont servies par le CMS
- Le bucket dev (`nosgestesclimat-dev.s3.fr-par.scw.cloud`) n'est pas modifié

### `remoteImagesPatterns.ts`

Suppression des patterns S3 prod — les images sont maintenant locales (chemin relatif).