### PR TITLE
⚡️ Proxifier les assets S3 via /_static/cms dans Nginx

### DIFF
--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -62,6 +62,12 @@ server {
         proxy_cache_lock on;
     }
 
+    location /_static/cms/ {
+        proxy_pass https://nosgestesclimat-prod.s3.fr-par.scw.cloud;
+        proxy_cache_valid 200 30d;
+        proxy_cache_lock on;
+    }
+
     location ~ ^/(_next/image|images|misc|fonts)/ {
         proxy_pass https://scalingo;
         proxy_cache_valid 200 30d;


### PR DESCRIPTION
## Why

Les assets servis depuis `nosgestesclimat-prod.s3.fr-par.scw.cloud` n'ont pas de `Cache-Control` approprié. Scaleway Object Storage ne les ajoute pas. Le navigateur re-télécharge ces assets à chaque visite.

## What

Ajoute un bloc `location /_static/cms/` qui reverse-proxy vers le bucket S3 :

```nginx
location /_static/cms/ {
    proxy_pass https://nosgestesclimat-prod.s3.fr-par.scw.cloud;
    proxy_cache_valid 200 365d;
    proxy_cache_lock on;
    proxy_hide_header Cache-Control;
    add_header Cache-Control "public, max-age=31536000, immutable" always;
}
```

- TTL 1 an avec `immutable` (les assets sont versionnés par hash dans leur nom de fichier)
- `proxy_hide_header` supprime le Cache-Control absent/incorrect de SCW

**⚠️ Cette PR doit être mergée ET déployée sur le proxy Nginx avant de merger la PR qui remplace les URLs dans l'app (#XXXX).**