### PR TITLE
⚡️ Ajouter /empreinte-carbone et /empreinte-eau au cache Nginx

### DIFF
--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -74,7 +74,7 @@ server {
         proxy_cache_lock on;
     }
 
-    location ~ ^/(en/)?(simulateur/tutoriel)?$ {
+    location ~ ^/(en/)?(simulateur/tutoriel|empreinte-carbone|empreinte-eau)?$ {
         proxy_pass https://scalingo;
 
         proxy_cache_key "$scheme$request_method$host$request_uri$ngc_is_auth";


### PR DESCRIPTION
## Why

Les landing pages `/empreinte-carbone` et `/empreinte-eau` comptent respectivement 8 285 et 1 071 visiteurs uniques sur 90 jours (PostHog). Leur contenu est identique pour tous les utilisateurs anonymes — seul le bouton "Mon espace" varie.

## What

Ajout de `empreinte-carbone` et `empreinte-eau` à la regex existante :

```
^/(en/)?(simulateur/tutoriel|empreinte-carbone|empreinte-eau)?$
```

Même TTL 30 min, même logique : `proxy_ignore_headers Cache-Control` + `proxy_cache_bypass`/`proxy_no_cache` pour les utilisateurs authentifiés.

### URLs couvertes

| URL | Cache ? |
|-----|--------|
| `/empreinte-carbone`, `/en/empreinte-carbone` | Oui |
| `/empreinte-eau`, `/en/empreinte-eau` | Oui |
| `/fr/empreinte-carbone` | Non (307 → `/empreinte-carbone`, Next.js marque `private`) |