### PR TITLE
♻️ use fix from posthog to register referrer & fix bug setting referring_entry_url (NGC-3747)

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -67,7 +67,7 @@
     "markdown-to-jsx": "^7.7.17",
     "next": "16.1.5",
     "next-i18n-router": "^5.5.6",
-    "posthog-js": "^1.379.0",
+    "posthog-js": "^1.406.1",
     "posthog-node": "^5.30.6",
     "publicodes": "^1.10.1",
     "react": "19.2.4",

--- a/apps/site/src/services/tracking/Posthog.ts
+++ b/apps/site/src/services/tracking/Posthog.ts
@@ -101,40 +101,14 @@ export class PostHog {
         'poll',
       ], // Enable to set query parameters as properties on the events
 
-      // PostHog recomputes $referrer/$referring_domain from the browser's
-      // real referrer on every capture and stores it in sessionPersistence,
-      // which always wins over the value we `register()` below. Disabling
-      // this in iframe mode lets our registered iframe referrer survive.
-      save_referrer: !this.iframeInformation.iframe,
-
-      // $session_entry_referrer/_referring_domain and the person-level
-      // $initial_referrer/_referring_domain (sent via $set_once) come from
-      // PostHog's session and person bootstrap logic, which always reads the
-      // real browser referrer and isn't gated by `save_referrer`. `before_send`
-      // is the only public hook that runs late enough to override them.
-      before_send: (event) => {
-        if (event && this.iframeInformation.iframe) {
-          const { $referrer, $referring_domain } = this.iframeInformation
-          event.properties.$session_entry_referrer = $referrer
-          event.properties.$session_entry_referring_domain = $referring_domain
-
-          if (event.$set_once) {
-            if ('$initial_referrer' in event.$set_once) {
-              event.$set_once.$initial_referrer = $referrer
-            }
-            if ('$initial_referring_domain' in event.$set_once) {
-              event.$set_once.$initial_referring_domain = $referring_domain
-            }
-          }
-        }
-        return event
+      loaded: () => {
+        this.registerProperties()
       },
     })
 
     if (savedCookieState.posthog === 'do_not_track') {
       this.switchDNTOn()
     }
-    this.registerProperties()
   }
 
   private registerProperties() {

--- a/apps/site/src/services/tracking/iframeInformation.ts
+++ b/apps/site/src/services/tracking/iframeInformation.ts
@@ -8,6 +8,8 @@ export type IframeInformation =
       iframe: true
       $referrer: string | undefined
       $referring_domain: string | undefined
+      // This property is included for backward compatibility with PostHog's property naming conventions used earlier.
+      $referringDomain: string | undefined
     }
 
 /**
@@ -35,8 +37,9 @@ export function getIframeInformation(): IframeInformation {
     //
   }
   return {
-    iframe,
+    iframe: true,
     $referrer: referrer,
     $referring_domain: referringDomain,
+    $referringDomain: referringDomain,
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,8 +322,8 @@ importers:
         specifier: ^5.5.6
         version: 5.5.6(next@16.1.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       posthog-js:
-        specifier: ^1.379.0
-        version: 1.382.0
+        specifier: ^1.406.1
+        version: 1.407.3
       posthog-node:
         specifier: ^5.30.6
         version: 5.30.6
@@ -2916,17 +2916,20 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@posthog/browser-common@0.2.3':
+    resolution: {integrity: sha512-LJOUcBLLjFOqw6ZZsjrCuojliJHFU/GYeOV88T+lXyePXJQnxFzuAouDtwwHFHtoaaOjfQ0OvDMR7J468Nkomw==}
+
   '@posthog/core@1.27.7':
     resolution: {integrity: sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==}
 
-  '@posthog/core@1.30.10':
-    resolution: {integrity: sha512-R7Z5jDB3ugwfSujMmRd5osPPR6L6BqfcaSNcYOekzRMZ4Jklq74p05xByP09EnUvKXb5czI+RQVCITTWRWuFXw==}
+  '@posthog/core@1.45.1':
+    resolution: {integrity: sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==}
 
   '@posthog/types@1.372.3':
     resolution: {integrity: sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==}
 
-  '@posthog/types@1.382.0':
-    resolution: {integrity: sha512-iK4OcSgvtmS9FZ9EUpvwlRZmHCLXaZ3+6dbRjkE7q9LL0zHLewxJH84H6uGvCw8aGzxs5rIliZqPHgimTcQEaw==}
+  '@posthog/types@1.398.0':
+    resolution: {integrity: sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg==}
 
   '@prisma/adapter-pg@7.8.0':
     resolution: {integrity: sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==}
@@ -8043,8 +8046,8 @@ packages:
     resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
     engines: {node: '>=12'}
 
-  posthog-js@1.382.0:
-    resolution: {integrity: sha512-lXwVlNdPLkhDft48ZgLQ5Jf4RsuQVwz7Hr7luD4DAG+4wDGA+k9eE2no36r3Z1w4uK0EmIf9lmav6+4RsmP7nA==}
+  posthog-js@1.407.3:
+    resolution: {integrity: sha512-b9Kc7HVN6nh+xsh1JrcLYHv9bbYLwYUM9belJtNVUFZSJWWfFcZRJJP6L+KeanAeu2VxSFSpioVA39pjjolv4A==}
 
   posthog-node@5.30.6:
     resolution: {integrity: sha512-deZuSiLkpdEipiywkww1FhQoKpVVFmJP6SAVQcZcMbugTLwJRYSGjgm+qV0Y91xghf2yP6Nr5Plfl52i9Qj15Q==}
@@ -8055,8 +8058,13 @@ packages:
       rxjs:
         optional: true
 
-  preact@10.29.0:
-    resolution: {integrity: sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==}
+  preact@10.29.7:
+    resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -9645,8 +9653,8 @@ packages:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
 
-  web-vitals@5.2.0:
-    resolution: {integrity: sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==}
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -12576,17 +12584,22 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@posthog/browser-common@0.2.3':
+    dependencies:
+      '@posthog/core': 1.45.1
+      '@posthog/types': 1.398.0
+
   '@posthog/core@1.27.7':
     dependencies:
       '@posthog/types': 1.372.3
 
-  '@posthog/core@1.30.10':
+  '@posthog/core@1.45.1':
     dependencies:
-      '@posthog/types': 1.382.0
+      '@posthog/types': 1.398.0
 
   '@posthog/types@1.372.3': {}
 
-  '@posthog/types@1.382.0': {}
+  '@posthog/types@1.398.0': {}
 
   '@prisma/adapter-pg@7.8.0':
     dependencies:
@@ -18902,22 +18915,25 @@ snapshots:
 
   postgres@3.4.7: {}
 
-  posthog-js@1.382.0:
+  posthog-js@1.407.3:
     dependencies:
-      '@posthog/core': 1.30.10
-      '@posthog/types': 1.382.0
+      '@posthog/browser-common': 0.2.3
+      '@posthog/core': 1.45.1
+      '@posthog/types': 1.398.0
       core-js: 3.49.0
       dompurify: 3.3.3
       fflate: 0.4.8
-      preact: 10.29.0
+      preact: 10.29.7
       query-selector-shadow-dom: 1.0.1
-      web-vitals: 5.2.0
+      web-vitals: 5.3.0
+    transitivePeerDependencies:
+      - preact-render-to-string
 
   posthog-node@5.30.6:
     dependencies:
       '@posthog/core': 1.27.7
 
-  preact@10.29.0: {}
+  preact@10.29.7: {}
 
   prelude-ls@1.2.1: {}
 
@@ -20743,7 +20759,7 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
-  web-vitals@5.2.0: {}
+  web-vitals@5.3.0: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ minimumReleaseAgeExclude:
   - 'posthog-js'
   - '@posthog/core'
   - '@posthog/types'
+  - '@posthog/browser-common'
 
 onlyBuiltDependencies:
   - '@incubateur-ademe/nosgestesclimat'


### PR DESCRIPTION
- Use new posthog version with register fix
- Use `loaded` init property to avoid setting empty referring domain => if a component mount before posthog init, it can send events without registered domaine

Si dans ton app React tu fais posthog.capture('$pageview') au mount d'un composant, il peut partir avant que l'iframe soit visible et donc avant que initPosthog() soit appelé. PostHog ignore les events avant init(), donc cet event serait perdu — mais le vrai risque c'est que ça crée une session sans $referring_domain.

Après investigation, je pense que c'est effectivement une bonne piste:

https://eu.posthog.com/project/75573/insights/alSUQief

Si on regarde ici les pageviews par unique session avec un breakdown par referring domain, on voit qu'un session peut envoyer des pageview avec 2 referring domain successivement none puis "untruc". Si on regarde juste la first ever occurence, on a que des none.
