### PR TITLE
🐛 Supprime proxy_set_header Host qui envoie le mauvais hostname à Scalingo

### DIFF
--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -47,7 +47,7 @@ server {
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
     add_header X-Cache-Status $upstream_cache_status;
 
-    proxy_set_header Host $host;
+    proxy_set_header Host ${UPSTREAM};
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto https;

--- a/infra/nginx/pull-config.sh
+++ b/infra/nginx/pull-config.sh
@@ -112,6 +112,8 @@ fi
 
 systemctl reload nginx
 
+sleep 1
+
 # ─── Health check ───────────────────────────────────────────────
 if ! curl -fsS --max-time 10 \
     --resolve "${DOMAIN}:443:127.0.0.1" \


### PR DESCRIPTION
## Pourquoi

Le domaine `preprod.nosgesteclimat.fr` affiche la page 404 Scalingo « application doesn't exist », alors que l'upstream direct `nosgestesclimat-site-preprod.osc-fr1.scalingo.io` fonctionne.

La cause est la directive `proxy_set_header Host ;` qui forçait le header `Host` à `preprod.nosgesteclimat.fr`. Comme ce domaine n'est pas déclaré côté Scalingo, le routeur Scalingo ne reconnaît pas l'application et renvoie une 404.

## Quoi

Suppression de la ligne `proxy_set_header Host ;` dans `infra/nginx/nginx.conf.tpl`.

Sans cette directive, nginx utilise `` par défaut, c'est-à-dire le hostname de l'upstream défini dans `proxy_pass` — celui que Scalingo reconnaît.

La ligne `proxy_set_header X-Forwarded-Host ;` est conservée pour que l'app Next.js connaisse le domaine d'origine de la requête.

## Vérification

Vérifier que `preprod.nosgesteclimat.fr` affiche bien l'application après déploiement du nouveau template nginx sur le serveur.