### PR TITLE
🐛 attempt fixing invalid authentication codes

### DIFF
--- a/apps/server/src/adapters/brevo/__tests__/fixtures/server.fixture.ts
+++ b/apps/server/src/adapters/brevo/__tests__/fixtures/server.fixture.ts
@@ -10,8 +10,10 @@ type CustomResponse = {
 
 export const brevoSendEmail = ({
   expectBody,
+  networkError,
 }: {
   expectBody?: unknown
+  networkError?: true
 } = {}) =>
   http.post(`${process.env.BREVO_URL}/v3/smtp/email`, async ({ request }) => {
     if (request.headers.get('api-key') !== process.env.BREVO_API_KEY) {
@@ -20,6 +22,10 @@ export const brevoSendEmail = ({
 
     if (expectBody) {
       expect(await request.json()).toEqual(expectBody)
+    }
+
+    if (networkError) {
+      return HttpResponse.error()
     }
 
     return HttpResponse.json()

--- a/apps/server/src/adapters/brevo/client.ts
+++ b/apps/server/src/adapters/brevo/client.ts
@@ -36,7 +36,10 @@ const brevo = axios.create({
   headers: {
     'api-key': config.thirdParty.brevo.apiKey,
   },
-  timeout: 1000,
+  timeout: 5_000,
+  'axios-retry': {
+    retries: 2,
+  },
 })
 
 axiosRetry(brevo, {

--- a/apps/server/src/adapters/brevo/client.ts
+++ b/apps/server/src/adapters/brevo/client.ts
@@ -147,16 +147,30 @@ const sendEmail = ({
   templateId: TemplateId
   params: { [key: string]: unknown }
 }) => {
-  return brevo.post('/v3/smtp/email', {
-    to: [
-      {
-        name: email,
-        email,
+  return brevo.post(
+    '/v3/smtp/email',
+    {
+      to: [
+        {
+          name: email,
+          email,
+        },
+      ],
+      templateId,
+      params,
+    },
+    {
+      // A client-side timeout only aborts our socket: Brevo has already received
+      // the request and will still deliver the email. Setting a timeout below Brevo's
+      // response time, turns single sends into timeouts and with retries, into duplicate emails.
+      timeout: 10_000,
+      'axios-retry': {
+        // Lower than the library default of 3 for the same reason: a retried send
+        // is a duplicate email whenever the previous attempt actually got through.
+        retries: 2,
       },
-    ],
-    templateId,
-    params,
-  })
+    }
+  )
 }
 
 const lastSimulationResult = ({

--- a/apps/server/src/adapters/brevo/client.ts
+++ b/apps/server/src/adapters/brevo/client.ts
@@ -170,7 +170,7 @@ const sendEmail = ({
       'axios-retry': {
         // Lower than the library default of 3 for the same reason: a retried send
         // is a duplicate email whenever the previous attempt actually got through.
-        retries: 2,
+        retries: 1,
       },
     }
   )

--- a/apps/server/src/core/errors/InvalidVerificationCodeException.ts
+++ b/apps/server/src/core/errors/InvalidVerificationCodeException.ts
@@ -1,0 +1,34 @@
+import { EntityNotFoundException } from './EntityNotFoundException.ts'
+
+/**
+ * Why a submitted verification code was rejected.
+ *
+ * The lookup matches email, code and expiration at once, so a miss on its own
+ * does not say whether the code was never requested, does not match, or simply
+ * expired - which is precisely what tells a user mistake apart from a broken
+ * code delivery.
+ */
+export type VerificationCodeRejection =
+  /** No code at all exists for that email */
+  | 'not_requested'
+  /** Codes exist for that email but none matches the submitted one */
+  | 'mismatch'
+  /** The submitted code exists but its expiration date has passed */
+  | 'expired'
+  /** The reason itself could not be determined */
+  | 'unknown'
+
+export class InvalidVerificationCodeException extends EntityNotFoundException {
+  readonly rejection: VerificationCodeRejection
+  readonly context: Record<string, unknown>
+
+  constructor(
+    rejection: VerificationCodeRejection,
+    context: Record<string, unknown> = {}
+  ) {
+    super(`VerificationCode not found (${rejection})`)
+    this.name = 'InvalidVerificationCodeException'
+    this.rejection = rejection
+    this.context = context
+  }
+}

--- a/apps/server/src/core/errors/InvalidVerificationCodeException.ts
+++ b/apps/server/src/core/errors/InvalidVerificationCodeException.ts
@@ -9,9 +9,9 @@ import { EntityNotFoundException } from './EntityNotFoundException.ts'
  * code delivery.
  */
 export type VerificationCodeRejection =
-  /** No code at all exists for that email */
-  | 'not_requested'
-  /** Codes exist for that email but none matches the submitted one */
+  /** The email never had any code issued to it, ever - not just none currently valid */
+  | 'never_requested'
+  /** A code exists for that email, current or past, but none matches the submitted one */
   | 'mismatch'
   /** The submitted code exists but its expiration date has passed */
   | 'expired'

--- a/apps/server/src/core/event-bus/best-effort.ts
+++ b/apps/server/src/core/event-bus/best-effort.ts
@@ -1,4 +1,5 @@
-import logger from '../../logger.ts'
+import { captureException } from '@sentry/node'
+import logger, { errorMeta } from '../../logger.ts'
 import type { EventBusEvent } from './event.ts'
 import type { Handler } from './handler.ts'
 
@@ -20,6 +21,17 @@ export const bestEffort =
     try {
       return await handler(event)
     } catch (error) {
-      logger.error(`Best effort handler failed for "${name}"`, error)
+      // Swallowed on purpose (see above), so this log and this Sentry event are
+      // the only trace left of a side effect that silently did not happen.
+      logger.error(`Best effort handler failed for "${name}"`, {
+        handler: name,
+        event: event.constructor.name,
+        ...errorMeta(error),
+      })
+
+      captureException(error, {
+        level: 'warning',
+        tags: { handler: name, event: event.constructor.name },
+      })
     }
   }

--- a/apps/server/src/core/event-bus/best-effort.ts
+++ b/apps/server/src/core/event-bus/best-effort.ts
@@ -1,0 +1,25 @@
+import logger from '../../logger.ts'
+import type { EventBusEvent } from './event.ts'
+import type { Handler } from './handler.ts'
+
+/**
+ * Wraps a handler whose failure must not fail the emitter.
+ *
+ * `EventBus.once` rejects as soon as one subscriber rejects, and services await
+ * it before answering the request. A side effect that is not part of the
+ * operation's contract - syncing a third party, sending a notification - would
+ * otherwise turn an already committed, successful operation into an error
+ * response, and leave the user retrying something that in fact succeeded.
+ */
+export const bestEffort =
+  <SubscribedEvent extends EventBusEvent>(
+    name: string,
+    handler: Handler<SubscribedEvent>
+  ): Handler<SubscribedEvent> =>
+  async (event) => {
+    try {
+      return await handler(event)
+    } catch (error) {
+      logger.error(`Best effort handler failed for "${name}"`, error)
+    }
+  }

--- a/apps/server/src/features/authentication/__tests__/create-verification-codes.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/create-verification-codes.spec.ts
@@ -273,6 +273,29 @@ describe('Given a NGC user', () => {
           .expect(StatusCodes.TOO_MANY_REQUESTS)
       })
     })
+    describe('And the email delivery fails', () => {
+      test('Then it still persists the verification code', async () => {
+        const email = faker.internet.email().toLocaleLowerCase()
+
+        mswServer.use(brevoSendEmail({ networkError: true }))
+
+        await agent
+          .post(url)
+          .send({ email })
+          .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+
+        // Brevo may well have delivered the message before failing us: rolling
+        // the code back here is what hands users a code that can never work.
+        const createdVerificationCode = await prisma.verificationCode.findFirst(
+          {
+            where: { email },
+          }
+        )
+
+        expect(createdVerificationCode).toMatchObject({ email, code })
+      })
+    })
+
     describe('And database failure', () => {
       const databaseError = new Error('Something went wrong')
 

--- a/apps/server/src/features/authentication/__tests__/create-verification-codes.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/create-verification-codes.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { prisma } from '@nosgestesclimat/core/prisma/client'
+import { captureException } from '@sentry/node'
 import { StatusCodes } from 'http-status-codes'
 import supertest from 'supertest'
 import {
@@ -18,10 +19,15 @@ import app from '../../../app.ts'
 import { mswServer } from '../../../core/__tests__/fixtures/server.fixture.ts'
 import { EventBus } from '../../../core/event-bus/event-bus.ts'
 import { Locales } from '../../../core/i18n/constant.ts'
-import logger from '../../../logger.ts'
+import logger, { maskEmail } from '../../../logger.ts'
 import * as authenticationService from '../authentication.service.ts'
 import type { VerificationCodeCreateDto } from '../verification-codes.validator.ts'
 import { CREATE_VERIFICATION_CODE_ROUTE } from './fixtures/verification-codes.fixture.ts'
+
+vi.mock('@sentry/node', async () => ({
+  ...(await vi.importActual('@sentry/node')),
+  captureException: vi.fn(),
+}))
 
 describe('Given a NGC user', () => {
   const agent = supertest(app)
@@ -319,13 +325,30 @@ describe('Given a NGC user', () => {
       })
 
       test('Then it logs the exception', async () => {
-        await agent.post(url).send({
-          email: faker.internet.email(),
-        })
+        const email = faker.internet.email().toLocaleLowerCase()
+
+        await agent.post(url).send({ email })
 
         expect(logger.error).toHaveBeenCalledWith(
           'VerificationCode creation failed',
-          databaseError
+          expect.objectContaining({
+            email: maskEmail(email),
+            message: databaseError.message,
+            stack: databaseError.stack,
+          })
+        )
+      })
+
+      test('Then it captures the exception', async () => {
+        const email = faker.internet.email().toLocaleLowerCase()
+
+        await agent.post(url).send({ email })
+
+        expect(captureException).toHaveBeenCalledWith(
+          databaseError,
+          expect.objectContaining({
+            extra: expect.objectContaining({ email: maskEmail(email) }),
+          })
         )
       })
     })

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { prisma } from '@nosgestesclimat/core/prisma/client'
+import { captureException } from '@sentry/node'
 import dayjs from 'dayjs'
 import { StatusCodes } from 'http-status-codes'
 import jwt from 'jsonwebtoken'
@@ -15,12 +16,17 @@ import app from '../../../app.ts'
 import { mswServer } from '../../../core/__tests__/fixtures/server.fixture.ts'
 import { EventBus } from '../../../core/event-bus/event-bus.ts'
 import { Locales } from '../../../core/i18n/constant.ts'
-import logger from '../../../logger.ts'
+import logger, { maskEmail } from '../../../logger.ts'
 import { LOGIN_ROUTE } from './fixtures/login.fixture.ts'
 import { createVerificationCode } from './fixtures/verification-codes.fixture.ts'
 
 vi.mock('../../../adapters/prisma/transaction', async () => ({
   ...(await vi.importActual('../../../adapters/prisma/transaction')),
+}))
+
+vi.mock('@sentry/node', async () => ({
+  ...(await vi.importActual('@sentry/node')),
+  captureException: vi.fn(),
 }))
 
 describe('Given a NGC user', () => {
@@ -91,6 +97,73 @@ describe('Given a NGC user', () => {
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
           })
           .expect(StatusCodes.UNAUTHORIZED)
+      })
+
+      test('Then it logs a rejection telling no code was requested', async () => {
+        const userId = faker.string.uuid()
+        const email = faker.internet.email().toLocaleLowerCase()
+
+        await agent.post(url).send({
+          userId,
+          email,
+          code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+        })
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Login rejected: invalid verification code',
+          expect.objectContaining({
+            userId,
+            email: maskEmail(email),
+            rejection: 'not_requested',
+          })
+        )
+      })
+
+      test('Then it captures the rejection', async () => {
+        const userId = faker.string.uuid()
+        const email = faker.internet.email().toLocaleLowerCase()
+
+        await agent.post(url).send({
+          userId,
+          email,
+          code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+        })
+
+        expect(captureException).toHaveBeenCalledWith(
+          expect.objectContaining({
+            rejection: 'not_requested',
+          }),
+          expect.objectContaining({
+            level: 'warning',
+          })
+        )
+      })
+    })
+
+    describe('And verification code does not match the one sent', () => {
+      test('Then it logs a mismatch rejection', async () => {
+        const verificationCode = await createVerificationCode({
+          agent,
+          code: '123456',
+        })
+
+        await agent
+          .post(url)
+          .send({
+            userId: faker.string.uuid(),
+            email: verificationCode.email,
+            code: '654321',
+          })
+          .expect(StatusCodes.UNAUTHORIZED)
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          'Login rejected: invalid verification code',
+          expect.objectContaining({
+            email: maskEmail(verificationCode.email),
+            rejection: 'mismatch',
+            latestExpirationDate: expect.any(Date),
+          })
+        )
       })
     })
 
@@ -214,6 +287,29 @@ describe('Given a NGC user', () => {
               userId: faker.string.uuid(),
             })
             .expect(StatusCodes.UNAUTHORIZED)
+        })
+
+        test('Then it logs an expired rejection', async () => {
+          const expirationDate = dayjs().subtract(1, 'second').toDate()
+          const verificationCode = await createVerificationCode({
+            agent,
+            expirationDate,
+          })
+
+          await agent.post(url).send({
+            email: verificationCode.email,
+            code: verificationCode.code,
+            userId: faker.string.uuid(),
+          })
+
+          expect(logger.warn).toHaveBeenCalledWith(
+            'Login rejected: invalid verification code',
+            expect.objectContaining({
+              email: maskEmail(verificationCode.email),
+              rejection: 'expired',
+              expirationDate,
+            })
+          )
         })
       })
 
@@ -484,6 +580,28 @@ describe('Given a NGC user', () => {
             })
             .expect(StatusCodes.FORBIDDEN)
         })
+
+        test('Then it logs the rejection', async () => {
+          const signInCode = await createVerificationCode({
+            agent,
+            verificationCode: { email: emailB },
+            mode: VerificationCodeMode.signIn,
+          })
+
+          await agent.post(url).send({
+            userId: userIdA,
+            email: signInCode.email,
+            code: signInCode.code,
+          })
+
+          expect(logger.warn).toHaveBeenCalledWith(
+            'Login rejected: userId attached to another account',
+            expect.objectContaining({
+              userId: userIdA,
+              email: maskEmail(emailB),
+            })
+          )
+        })
       })
     })
 
@@ -512,13 +630,42 @@ describe('Given a NGC user', () => {
       })
 
       test('Then it logs the exception', async () => {
+        const userId = faker.string.uuid()
+        const email = faker.internet.email().toLocaleLowerCase()
+
         await agent.post(url).send({
-          userId: faker.string.uuid(),
-          email: faker.internet.email(),
+          userId,
+          email,
           code: faker.number.int({ min: 100000, max: 999999 }).toString(),
         })
 
-        expect(logger.error).toHaveBeenCalledWith('Login failed', databaseError)
+        expect(logger.error).toHaveBeenCalledWith(
+          'Login failed',
+          expect.objectContaining({
+            userId,
+            email: maskEmail(email),
+            message: databaseError.message,
+            stack: databaseError.stack,
+          })
+        )
+      })
+
+      test('Then it captures the exception', async () => {
+        const userId = faker.string.uuid()
+        const email = faker.internet.email().toLocaleLowerCase()
+
+        await agent.post(url).send({
+          userId,
+          email,
+          code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+        })
+
+        expect(captureException).toHaveBeenCalledWith(
+          databaseError,
+          expect.objectContaining({
+            extra: expect.objectContaining({ userId, email: maskEmail(email) }),
+          })
+        )
       })
     })
   })

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -152,6 +152,53 @@ describe('Given a NGC user', () => {
         await EventBus.flush()
       })
 
+      describe('And brevo is unavailable', () => {
+        test(`Then it still returns a ${StatusCodes.OK} response`, async () => {
+          const verificationCode = await createVerificationCode({ agent })
+
+          mswServer.use(
+            brevoUpdateContact({ networkError: true }),
+            brevoSendEmail({ networkError: true })
+          )
+
+          await agent
+            .post(url)
+            .send({
+              userId: faker.string.uuid(),
+              email: verificationCode.email,
+              code: verificationCode.code,
+            })
+            .expect(StatusCodes.OK)
+
+          await EventBus.flush()
+        })
+
+        test('Then it still creates the verified user', async () => {
+          const { email, code } = await createVerificationCode({
+            agent,
+            mode: VerificationCodeMode.signUp,
+          })
+
+          mswServer.use(
+            brevoUpdateContact({ networkError: true }),
+            brevoSendEmail({ networkError: true })
+          )
+
+          await agent
+            .post(url)
+            .send({ userId: faker.string.uuid(), email, code })
+            .expect(StatusCodes.OK)
+
+          const createdUser = await prisma.verifiedUser.findUnique({
+            where: { email },
+          })
+
+          expect(createdUser).not.toBeNull()
+
+          await EventBus.flush()
+        })
+      })
+
       describe('And is expired', () => {
         test(`Then it returns a ${StatusCodes.UNAUTHORIZED} error`, async () => {
           const verificationCode = await createVerificationCode({

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -114,7 +114,7 @@ describe('Given a NGC user', () => {
           expect.objectContaining({
             userId,
             email: maskEmail(email),
-            rejection: 'not_requested',
+            rejection: 'never_requested',
           })
         )
       })
@@ -131,7 +131,7 @@ describe('Given a NGC user', () => {
 
         expect(captureException).toHaveBeenCalledWith(
           expect.objectContaining({
-            rejection: 'not_requested',
+            rejection: 'never_requested',
           }),
           expect.objectContaining({
             level: 'warning',

--- a/apps/server/src/features/authentication/authentication.controller.ts
+++ b/apps/server/src/features/authentication/authentication.controller.ts
@@ -1,11 +1,13 @@
+import { captureException } from '@sentry/node'
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { config } from '../../config.ts'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { ForbiddenException } from '../../core/errors/ForbiddenException.ts'
+import { InvalidVerificationCodeException } from '../../core/errors/InvalidVerificationCodeException.ts'
 import { bestEffort } from '../../core/event-bus/best-effort.ts'
 import { EventBus } from '../../core/event-bus/event-bus.ts'
-import logger from '../../logger.ts'
+import logger, { errorMeta, maskEmail } from '../../logger.ts'
 import { rateLimitSameRequestMiddleware } from '../../middlewares/rateLimitSameRequestMiddleware.ts'
 import { validateRequest } from '../../middlewares/validateRequest.ts'
 import {
@@ -48,25 +50,83 @@ router
     }),
     validateRequest(LoginValidator),
     async (req, res) => {
+      const startedAt = Date.now()
+      const context = {
+        userId: req.body.userId,
+        email: maskEmail(req.body.email),
+        locale: req.query.locale,
+      }
+
+      // Every branch below logs an outcome, so an attempt left without one is
+      // how a request that hung - or killed the process - stays visible.
+      logger.info('Login attempt', context)
+
       try {
-        const { token, user } = await login({
+        const { token, user, mode } = await login({
           loginDto: req.body,
           locale: req.query.locale,
         })
 
         res.cookie(COOKIE_NAME, token, getCookieOptions(config.app.origin))
 
+        logger.info('Login succeeded', {
+          ...context,
+          mode,
+          durationMs: Date.now() - startedAt,
+        })
+
         return res.status(StatusCodes.OK).json(user)
       } catch (err) {
+        const outcome = { ...context, durationMs: Date.now() - startedAt }
+
+        if (err instanceof InvalidVerificationCodeException) {
+          const rejected = {
+            ...outcome,
+            rejection: err.rejection,
+            ...err.context,
+          }
+
+          logger.warn('Login rejected: invalid verification code', rejected)
+
+          captureException(err, {
+            level: 'warning',
+            extra: rejected,
+          })
+
+          return res.status(StatusCodes.UNAUTHORIZED).end()
+        }
+
         if (err instanceof EntityNotFoundException) {
+          logger.warn('Login rejected: entity not found', {
+            ...outcome,
+            ...errorMeta(err),
+          })
+
+          captureException(err, {
+            level: 'warning',
+            extra: outcome,
+          })
+
           return res.status(StatusCodes.UNAUTHORIZED).end()
         }
 
         if (err instanceof ForbiddenException) {
+          logger.warn('Login rejected: userId attached to another account', {
+            ...outcome,
+            ...errorMeta(err),
+          })
+
+          captureException(err, {
+            level: 'warning',
+            extra: outcome,
+          })
+
           return res.status(StatusCodes.FORBIDDEN).end()
         }
 
-        logger.error('Login failed', err)
+        logger.error('Login failed', { ...outcome, ...errorMeta(err) })
+
+        captureException(err, { extra: outcome })
 
         return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()
       }

--- a/apps/server/src/features/authentication/authentication.controller.ts
+++ b/apps/server/src/features/authentication/authentication.controller.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 import { config } from '../../config.ts'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { ForbiddenException } from '../../core/errors/ForbiddenException.ts'
+import { bestEffort } from '../../core/event-bus/best-effort.ts'
 import { EventBus } from '../../core/event-bus/event-bus.ts'
 import logger from '../../logger.ts'
 import { rateLimitSameRequestMiddleware } from '../../middlewares/rateLimitSameRequestMiddleware.ts'
@@ -22,8 +23,13 @@ import { updateBrevoContact } from './handlers/update-brevo-contact.ts'
 
 const router = express.Router()
 
-EventBus.on(LoginEvent, updateBrevoContact)
-EventBus.on(LoginEvent, sendBrevoWelcomeEmail)
+// Brevo is not part of the login contract: authentication is settled once the
+// transaction commits, so a slow or failing Brevo must not turn it into a 500.
+EventBus.on(LoginEvent, bestEffort('updateBrevoContact', updateBrevoContact))
+EventBus.on(
+  LoginEvent,
+  bestEffort('sendBrevoWelcomeEmail', sendBrevoWelcomeEmail)
+)
 EventBus.on(LoginEvent, reconcileSimulationsAfterLogin)
 EventBus.on(AccountCreatedEvent, syncUserDataAfterAccountCreated)
 

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -11,8 +11,8 @@ import { defaultVerifiedUserSelection } from '../../adapters/prisma/selection.ts
 import type { Session } from '../../adapters/prisma/transaction.ts'
 import { transaction } from '../../adapters/prisma/transaction.ts'
 import { config } from '../../config.ts'
-import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { ForbiddenException } from '../../core/errors/ForbiddenException.ts'
+import { InvalidVerificationCodeException } from '../../core/errors/InvalidVerificationCodeException.ts'
 import { EventBus } from '../../core/event-bus/event-bus.ts'
 import type { Locales } from '../../core/i18n/constant.ts'
 import {
@@ -23,7 +23,9 @@ import type { LoginDto } from './authentication.validator.ts'
 import { AccountCreatedEvent } from './events/AccountCreated.event.ts'
 import { LoginEvent } from './events/Login.event.ts'
 import {
+  findLatestVerificationCodeForEmail,
   findVerificationCode,
+  findVerificationCodeIgnoringExpiration,
   invalidateVerificationCode,
 } from './verification-codes.repository.ts'
 
@@ -49,6 +51,50 @@ export const generateRandomVerificationCode = () =>
     Math.pow(10, 5) + Math.random() * (Math.pow(10, 6) - Math.pow(10, 5) - 1)
   ).toString()
 
+/**
+ * Reads back the codes stored for that email to tell *why* the lookup missed.
+ *
+ * Runs on the rejection path only, and never throws: a failed diagnosis must not
+ * replace the rejection the caller is about to answer with.
+ */
+const diagnoseVerificationCodeRejection = async (
+  { email, code }: Pick<VerificationCode, 'email' | 'code'>,
+  { session }: { session?: Session } = {}
+): Promise<InvalidVerificationCodeException> => {
+  try {
+    const [submittedCode, latestCode] = await transaction(
+      (session) =>
+        Promise.all([
+          findVerificationCodeIgnoringExpiration({ email, code }, { session }),
+          findLatestVerificationCodeForEmail({ email }, { session }),
+        ]),
+      session || prisma
+    )
+
+    if (submittedCode) {
+      return new InvalidVerificationCodeException('expired', {
+        verificationCodeId: submittedCode.id,
+        createdAt: submittedCode.createdAt,
+        expirationDate: submittedCode.expirationDate,
+      })
+    }
+
+    if (latestCode) {
+      return new InvalidVerificationCodeException('mismatch', {
+        latestVerificationCodeId: latestCode.id,
+        latestCreatedAt: latestCode.createdAt,
+        latestExpirationDate: latestCode.expirationDate,
+      })
+    }
+
+    return new InvalidVerificationCodeException('not_requested')
+  } catch (e) {
+    return new InvalidVerificationCodeException('unknown', {
+      diagnosisError: e instanceof Error ? e.message : String(e),
+    })
+  }
+}
+
 export const verifyCode = async (
   verificationCode: Pick<VerificationCode, 'email' | 'code'>,
   { session }: { session?: Session } = {}
@@ -60,7 +106,9 @@ export const verifyCode = async (
     )
   } catch (e) {
     if (isPrismaErrorNotFound(e)) {
-      throw new EntityNotFoundException('VerificationCode not found')
+      throw await diagnoseVerificationCodeRejection(verificationCode, {
+        session,
+      })
     }
     throw e
   }
@@ -86,7 +134,7 @@ export const login = async ({
 
   await EventBus.once(loginEvent)
 
-  return { token, user }
+  return { token, user, mode }
 }
 
 export function createToken(user: Pick<VerifiedUser, 'id' | 'email'>) {

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -24,6 +24,7 @@ import { AccountCreatedEvent } from './events/AccountCreated.event.ts'
 import { LoginEvent } from './events/Login.event.ts'
 import {
   findLatestVerificationCodeForEmail,
+  findValidVerificationCodesForEmail,
   findVerificationCode,
   findVerificationCodeIgnoringExpiration,
   invalidateVerificationCode,
@@ -64,14 +65,16 @@ const diagnoseVerificationCodeRejection = async (
   try {
     const diagnosisStartedAt = new Date()
 
-    const [submittedCode, latestCode] = await transaction(
+    const [submittedCode, latestCode, validCodes] = await transaction(
       (session) =>
         Promise.all([
           findVerificationCodeIgnoringExpiration({ email, code }, { session }),
           findLatestVerificationCodeForEmail({ email }, { session }),
+          findValidVerificationCodesForEmail({ email }, { session }),
         ]),
       session || prisma
     )
+    const validVerificationCodeIds = validCodes.map(({ id }) => id)
 
     // Given code exists for this email but expired
     if (submittedCode) {
@@ -80,21 +83,26 @@ const diagnoseVerificationCodeRejection = async (
         createdAt: submittedCode.createdAt,
         expirationDate: submittedCode.expirationDate,
         latestExpired: submittedCode.expirationDate < diagnosisStartedAt,
+        validVerificationCodeIds,
       })
     }
 
-    // Given code doesn't exist, compare with latest code for debugging purpose
+    // Given code doesn't exist, compare with latest code for debugging purpose.
+    // The latest code may itself be expired: it only tells us a code was
+    // requested at some point, not that the user had a valid one to use -
+    // validVerificationCodeIds carries that second, more actionable signal.
     if (latestCode) {
       return new InvalidVerificationCodeException('mismatch', {
         latestVerificationCodeId: latestCode.id,
         latestCreatedAt: latestCode.createdAt,
         latestExpirationDate: latestCode.expirationDate,
         latestExpired: latestCode.expirationDate < diagnosisStartedAt,
+        validVerificationCodeIds,
       })
     }
 
-    // No existing authentication code found at all for this email
-    return new InvalidVerificationCodeException('not_requested')
+    // No code was ever issued for this email, not even one that already expired
+    return new InvalidVerificationCodeException('never_requested')
   } catch (e) {
     return new InvalidVerificationCodeException('unknown', {
       diagnosisError: e instanceof Error ? e.message : String(e),

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -62,6 +62,8 @@ const diagnoseVerificationCodeRejection = async (
   { session }: { session?: Session } = {}
 ): Promise<InvalidVerificationCodeException> => {
   try {
+    const diagnosisStartedAt = new Date()
+
     const [submittedCode, latestCode] = await transaction(
       (session) =>
         Promise.all([
@@ -71,22 +73,27 @@ const diagnoseVerificationCodeRejection = async (
       session || prisma
     )
 
+    // Given code exists for this email but expired
     if (submittedCode) {
       return new InvalidVerificationCodeException('expired', {
         verificationCodeId: submittedCode.id,
         createdAt: submittedCode.createdAt,
         expirationDate: submittedCode.expirationDate,
+        latestExpired: submittedCode.expirationDate < diagnosisStartedAt,
       })
     }
 
+    // Given code doesn't exist, compare with latest code for debugging purpose
     if (latestCode) {
       return new InvalidVerificationCodeException('mismatch', {
         latestVerificationCodeId: latestCode.id,
         latestCreatedAt: latestCode.createdAt,
         latestExpirationDate: latestCode.expirationDate,
+        latestExpired: latestCode.expirationDate < diagnosisStartedAt,
       })
     }
 
+    // No existing authentication code found at all for this email
     return new InvalidVerificationCodeException('not_requested')
   } catch (e) {
     return new InvalidVerificationCodeException('unknown', {

--- a/apps/server/src/features/authentication/verification-codes.controller.ts
+++ b/apps/server/src/features/authentication/verification-codes.controller.ts
@@ -1,7 +1,8 @@
+import { captureException } from '@sentry/node'
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { EventBus } from '../../core/event-bus/event-bus.ts'
-import logger from '../../logger.ts'
+import logger, { errorMeta, maskEmail } from '../../logger.ts'
 import { rateLimitSameRequestMiddleware } from '../../middlewares/rateLimitSameRequestMiddleware.ts'
 import { validateRequest } from '../../middlewares/validateRequest.ts'
 import { VerificationCodeCreatedEvent } from './events/VerificationCodeCreated.event.ts'
@@ -28,17 +29,39 @@ router.route('/v1/').post(
   }),
   validateRequest(VerificationCodeCreateValidator),
   async (req, res) => {
+    const startedAt = Date.now()
+    const context = {
+      email: maskEmail(req.body.email),
+      locale: req.query.locale,
+    }
+
     try {
       const verificationCode = await createVerificationCode({
         verificationCodeDto: req.body,
         ...req.query,
       })
+
+      logger.info('VerificationCode created', {
+        ...context,
+        expirationDate: verificationCode.expirationDate,
+        durationMs: Date.now() - startedAt,
+      })
+
       return res.status(StatusCodes.CREATED).json({
         email: verificationCode.email,
         expirationDate: verificationCode.expirationDate,
       })
     } catch (err) {
-      logger.error('VerificationCode creation failed', err)
+      const outcome = { ...context, durationMs: Date.now() - startedAt }
+
+      logger.error('VerificationCode creation failed', {
+        ...outcome,
+        ...errorMeta(err),
+      })
+
+      captureException(err, {
+        extra: outcome,
+      })
 
       return res.status(StatusCodes.INTERNAL_SERVER_ERROR).end()
     }

--- a/apps/server/src/features/authentication/verification-codes.repository.ts
+++ b/apps/server/src/features/authentication/verification-codes.repository.ts
@@ -64,6 +64,36 @@ export const findVerificationCode = (
   }) as Promise<UserVerificationCode>
 }
 
+export const findVerificationCodeIgnoringExpiration = (
+  { email, code }: Pick<VerificationCode, 'email' | 'code'>,
+  { session }: { session: Session }
+) => {
+  return session.verificationCode.findFirst({
+    where: { email, code },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      createdAt: true,
+      expirationDate: true,
+    },
+  })
+}
+
+export const findLatestVerificationCodeForEmail = (
+  { email }: Pick<VerificationCode, 'email'>,
+  { session }: { session: Session }
+) => {
+  return session.verificationCode.findFirst({
+    where: { email },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      createdAt: true,
+      expirationDate: true,
+    },
+  })
+}
+
 export const invalidateVerificationCode = (
   { id }: Pick<VerificationCode, 'id'>,
   { session }: { session: Session }

--- a/apps/server/src/features/authentication/verification-codes.repository.ts
+++ b/apps/server/src/features/authentication/verification-codes.repository.ts
@@ -94,6 +94,21 @@ export const findLatestVerificationCodeForEmail = (
   })
 }
 
+export const findValidVerificationCodesForEmail = (
+  { email }: Pick<VerificationCode, 'email'>,
+  { session }: { session: Session }
+) => {
+  return session.verificationCode.findMany({
+    where: { email, expirationDate: { gte: new Date() } },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      createdAt: true,
+      expirationDate: true,
+    },
+  })
+}
+
 export const invalidateVerificationCode = (
   { id }: Pick<VerificationCode, 'id'>,
   { session }: { session: Session }

--- a/apps/server/src/features/authentication/verification-codes.service.ts
+++ b/apps/server/src/features/authentication/verification-codes.service.ts
@@ -36,7 +36,7 @@ export const generateVerificationCode = async (
   return { code, verificationCode }
 }
 
-export const createVerificationCode = (
+export const createVerificationCode = async (
   {
     verificationCodeDto,
     locale,
@@ -47,27 +47,36 @@ export const createVerificationCode = (
   { session: parentSession }: { session?: Session } = {}
 ): Promise<{ email: string; expirationDate: Date }> => {
   const expirationDate = dayjs().add(1, 'hour').toDate()
-  return transaction(async (session) => {
-    const { verificationCode, code } = await generateVerificationCode(
-      { verificationCodeDto, expirationDate },
-      { session }
-    )
 
-    const verificationCodeCreatedEvent = new VerificationCodeCreatedEvent({
-      verificationCode: {
-        ...verificationCode,
-        code,
-      },
-      locale,
-    })
+  // The code must be committed *before* the email is handed to Brevo. Sending
+  // inside the transaction means any later failure (a Brevo timeout, or the
+  // call simply outliving the interactive transaction budget) rolls the row
+  // back after Brevo has already accepted — and delivered — the message. The
+  // user then holds a legitimate-looking code that does not exist in database,
+  // and every attempt to use it comes back as "invalid".
+  const { verificationCode, code } = await transaction(
+    (session) =>
+      generateVerificationCode(
+        { verificationCodeDto, expirationDate },
+        { session }
+      ),
+    parentSession
+  )
 
-    EventBus.emit(verificationCodeCreatedEvent)
+  const verificationCodeCreatedEvent = new VerificationCodeCreatedEvent({
+    verificationCode: {
+      ...verificationCode,
+      code,
+    },
+    locale,
+  })
 
-    await EventBus.once(verificationCodeCreatedEvent)
+  EventBus.emit(verificationCodeCreatedEvent)
 
-    return {
-      email: verificationCode.email,
-      expirationDate: verificationCode.expirationDate,
-    }
-  }, parentSession)
+  await EventBus.once(verificationCodeCreatedEvent)
+
+  return {
+    email: verificationCode.email,
+    expirationDate: verificationCode.expirationDate,
+  }
 }

--- a/apps/server/src/logger.ts
+++ b/apps/server/src/logger.ts
@@ -45,6 +45,29 @@ export const redactBody = <T = unknown>(body: T) => {
   return body
 }
 
+/**
+ * Keeps a log line correlatable with a user report without storing the address:
+ * `jo***@example.com` is enough to match an email a user gives us in support.
+ */
+export const maskEmail = (email: unknown) => {
+  if (typeof email !== 'string') {
+    return '[REDACTED]'
+  }
+
+  const [local, domain] = email.split('@')
+
+  return domain ? `${local.slice(0, 2)}***@${domain}` : '[REDACTED]'
+}
+
+/**
+ * Flattens an error into log metadata. `message` and `stack` are picked up by
+ * winston (and forwarded to Sentry) while the rest of the metadata is kept.
+ */
+export const errorMeta = (err: unknown) =>
+  err instanceof Error
+    ? { name: err.name, message: err.message, stack: err.stack }
+    : { message: String(err) }
+
 const logger = winston.createLogger({
   level: process.env.LOG_LEVEL ?? 'info',
   defaultMeta: {

--- a/apps/server/src/logger.ts
+++ b/apps/server/src/logger.ts
@@ -47,7 +47,7 @@ export const redactBody = <T = unknown>(body: T) => {
 
 /**
  * Keeps a log line correlatable with a user report without storing the address:
- * `jo***@example.com` is enough to match an email a user gives us in support.
+ * `jo***@ex***.com` is enough to match an email a user gives us in support.
  */
 export const maskEmail = (email: unknown) => {
   if (typeof email !== 'string') {
@@ -56,7 +56,9 @@ export const maskEmail = (email: unknown) => {
 
   const [local, domain] = email.split('@')
 
-  return domain ? `${local.slice(0, 2)}***@${domain}` : '[REDACTED]'
+  return domain
+    ? `${local.slice(0, 2)}***@${domain.slice(0, 2)}***`
+    : '[REDACTED]'
 }
 
 /**


### PR DESCRIPTION
J'ai durci l'usage de Brevo pour qu'une erreur ou un timeout côté Brevo ne puisse pas causer l'envoi d'un mail dont le code a été rollback ou qu'une erreur dans les événements ne puisse pas causer une réponse d'erreur alors que le code a été consommé.

Je n'ai pas touché à la gestion des erreurs pour ne pas entrer en conflit avec https://github.com/incubateur-ademe/nosgestesclimat-app/pull/1942

J'ai également relu le code à la main et je pense qu'il y a d'autres choses qui devraient être refactor mais je ne suis pas sûr que ça soit la cause du problème.