### PR TITLE
🔧 Ajoute résilience DNS et retry systemd pour nginx

### DIFF
--- a/.github/workflows/infra:nginx-lint.yaml
+++ b/.github/workflows/infra:nginx-lint.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   validate:
     name: Validate nginx.conf.tpl syntax
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     timeout-minutes: 5
 
     steps:

--- a/infra/nginx/cloud-init.tpl.yaml
+++ b/infra/nginx/cloud-init.tpl.yaml
@@ -22,6 +22,16 @@ write_files:
       REPO=__REPO__
       TEMPLATE_REF=__TEMPLATE_REF__
 
+  - path: /etc/systemd/system/nginx.service.d/override.conf
+    permissions: '0644'
+    content: |
+      [Service]
+      Restart=on-failure
+      RestartSec=10s
+      TimeoutStartSec=60s
+      StartLimitIntervalSec=3600
+      StartLimitBurst=360
+
 runcmd:
   - mkdir -p /var/cache/nginx /var/lib/nginx-config
   - chown -R www-data:www-data /var/cache/nginx

--- a/infra/nginx/nginx.conf.tpl
+++ b/infra/nginx/nginx.conf.tpl
@@ -10,8 +10,11 @@ map $cookie_ngc_session $ngc_is_auth {
     default  1;
 }
 
+resolver 1.1.1.1 8.8.8.8 valid=30s;
+
 upstream scalingo {
-    server ${UPSTREAM}:443;
+    zone scalingo 64k;
+    server ${UPSTREAM}:443 resolve;
     keepalive 64;
 }
 


### PR DESCRIPTION
## Pourquoi

Le 1er août 2026, nginx est resté down pendant ~24h sur la preprod après un redémarrage : la résolution DNS du hostname Scalingo (`nosgestesclimat-site-preprod.osc-fr1.scalingo.io`) a échoué au parsing de la config, provoquant un `host not found in upstream` et l'échec du démarrage du service.

Ce changement rend nginx résilient à ce scénario sur deux couches complémentaires.

## Ce qui change

### `nginx.conf.tpl` — résolution DNS dynamique

```nginx
resolver 1.1.1.1 8.8.8.8 valid=30s;

upstream scalingo {
    zone scalingo 64k;
    server ${UPSTREAM}:443 resolve;
    keepalive 64;
}
```

- **`resolver`** + **`resolve`** : nginx re-résout le hostname périodiquement au runtime plutôt qu'une seule fois au parsing. En cas de reload avec DNS temporairement down, l'ancien worker garde l'IP en cache.
- **`zone`** : requis par nginx pour le `resolve` — définit une zone de mémoire partagée de 64k pour stocker les IPs résolues.

### `cloud-init.tpl.yaml` — système de retry au niveau systemd

Déploie `/etc/systemd/system/nginx.service.d/override.conf` :

```ini
[Service]
Restart=on-failure
RestartSec=10s
TimeoutStartSec=60s
StartLimitIntervalSec=3600
StartLimitBurst=360
```

Si nginx échoue à démarrer (cold start avec DNS down), systemd retente toutes les 10 secondes pendant 1 heure maximum.

## Vérification

Testé sur la preprod : `nginx-config-pull.sh` passe sans erreur après ajout de la directive `zone`.

## Déploiement

- **Nouvelles instances** : l'override est écrit par cloud-init
- **Instances existantes** : déployer l'override manuellement :

```bash
mkdir -p /etc/systemd/system/nginx.service.d
cat > /etc/systemd/system/nginx.service.d/override.conf << 'EOF'
[Service]
Restart=on-failure
RestartSec=10s
TimeoutStartSec=60s
StartLimitIntervalSec=3600
StartLimitBurst=360
EOF
systemctl daemon-reload
```