### PR TITLE
🐛 Preserve group participants name (NGC-3634)

### DIFF
--- a/apps/server/src/features/groups/__tests__/create-group-participant.spec.ts
+++ b/apps/server/src/features/groups/__tests__/create-group-participant.spec.ts
@@ -209,6 +209,7 @@ describe('Given a NGC user', () => {
       test('Then it does not overwrite an existing participant name with an empty name', async () => {
         const userId = faker.string.uuid()
         const participantName = faker.person.fullName()
+        const updatedName = faker.person.fullName()
 
         await agent
           .post(url.replace(':groupId', groupId))
@@ -248,6 +249,34 @@ describe('Given a NGC user', () => {
         })
 
         expect(createdParticipant?.user.name).toBe(participantName)
+
+        // A non-empty name must still update the participant name.
+        await agent
+          .post(url.replace(':groupId', groupId))
+          .set(authHeaders({ userId }))
+          .send({
+            name: updatedName,
+            simulation: getSimulationPayload(),
+          })
+          .expect(StatusCodes.CREATED)
+
+        const updatedParticipant = await prisma.groupParticipant.findUnique({
+          where: {
+            groupId_userId: {
+              groupId,
+              userId,
+            },
+          },
+          select: {
+            user: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        })
+
+        expect(updatedParticipant?.user.name).toBe(updatedName)
       })
 
       test('Then it stores the participant simulation in database', async () => {

--- a/apps/server/src/features/groups/__tests__/create-group-participant.spec.ts
+++ b/apps/server/src/features/groups/__tests__/create-group-participant.spec.ts
@@ -206,6 +206,50 @@ describe('Given a NGC user', () => {
         })
       })
 
+      test('Then it does not overwrite an existing participant name with an empty name', async () => {
+        const userId = faker.string.uuid()
+        const participantName = faker.person.fullName()
+
+        await agent
+          .post(url.replace(':groupId', groupId))
+          .set(authHeaders({ userId }))
+          .send({
+            name: participantName,
+            simulation: getSimulationPayload(),
+          })
+          .expect(StatusCodes.CREATED)
+
+        // Simulates the call made when an anonymous participant completes
+        // its test: the client has no name in its session and sends an
+        // empty `name`, which must not erase the previously saved one.
+        await agent
+          .post(url.replace(':groupId', groupId))
+          .set(authHeaders({ userId }))
+          .send({
+            name: '',
+            simulation: getSimulationPayload(),
+          })
+          .expect(StatusCodes.CREATED)
+
+        const createdParticipant = await prisma.groupParticipant.findUnique({
+          where: {
+            groupId_userId: {
+              groupId,
+              userId,
+            },
+          },
+          select: {
+            user: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        })
+
+        expect(createdParticipant?.user.name).toBe(participantName)
+      })
+
       test('Then it stores the participant simulation in database', async () => {
         const userId = faker.string.uuid()
         const payload: ParticipantInputCreateDto = {

--- a/apps/server/src/features/groups/groups.repository.ts
+++ b/apps/server/src/features/groups/groups.repository.ts
@@ -7,7 +7,7 @@ import {
 import type { Session } from '../../adapters/prisma/transaction.ts'
 import type { PartialUser } from '../../core/types/user.ts'
 import { createParticipantSimulation } from '../simulations/simulations.repository.ts'
-import { createOrUpdateUser } from '../users/users.repository.ts'
+import { createOrUpdateUser, fetchUser } from '../users/users.repository.ts'
 import type {
   GroupCreateDto,
   GroupParams,
@@ -153,12 +153,20 @@ export const createParticipantAndUser = async (
     },
   })
 
+  // An anonymous participant completing its test sends an empty `name`
+  // (its session holds no display name). Keep the previously saved name
+  // instead of overwriting it with an empty string.
+  const existingUser = await fetchUser(
+    { id: userId, select: { name: true } },
+    { session }
+  )
+
   // upsert user
   await createOrUpdateUser(
     {
       id: userId,
       user: {
-        name,
+        name: name || existingUser?.name,
       },
     },
     { session }

--- a/apps/server/src/features/groups/groups.repository.ts
+++ b/apps/server/src/features/groups/groups.repository.ts
@@ -7,7 +7,7 @@ import {
 import type { Session } from '../../adapters/prisma/transaction.ts'
 import type { PartialUser } from '../../core/types/user.ts'
 import { createParticipantSimulation } from '../simulations/simulations.repository.ts'
-import { createOrUpdateUser, fetchUser } from '../users/users.repository.ts'
+import { createOrUpdateUser } from '../users/users.repository.ts'
 import type {
   GroupCreateDto,
   GroupParams,
@@ -153,21 +153,13 @@ export const createParticipantAndUser = async (
     },
   })
 
-  // An anonymous participant completing its test sends an empty `name`
-  // (its session holds no display name). Keep the previously saved name
-  // instead of overwriting it with an empty string.
-  const existingUser = await fetchUser(
-    { id: userId, select: { name: true } },
-    { session }
-  )
-
-  // upsert user
+  // upsert user. An anonymous participant completing its test sends an empty
+  // `name` (its session holds no display name); skip the `name` field in that
+  // case so Prisma does not overwrite the previously saved name.
   await createOrUpdateUser(
     {
       id: userId,
-      user: {
-        name: name || existingUser?.name,
-      },
+      user: name ? { name } : {},
     },
     { session }
   )

--- a/apps/site/e2e/features/groups.spec.ts
+++ b/apps/site/e2e/features/groups.spec.ts
@@ -148,9 +148,7 @@ test.describe('A new user', () => {
     await expect(page).toHaveURL(group.url)
   })
 
-  // TODO: Fails because updateGroupParticipant does not persist the participant name
-  // on the server side for non-admin users. The ranking displays empty names.
-  test.skip('sees its first name in the group ranking after joining', async ({
+  test('sees its first name in the group ranking after joining', async ({
     page,
     ngcTest,
     tutorialPage,

--- a/apps/site/src/app/[locale]/(server)/(large)/amis/creer/votre-groupe/_components/NameForm.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/amis/creer/votre-groupe/_components/NameForm.tsx
@@ -86,6 +86,7 @@ export default function NameForm({
       <PrenomInput
         data-testid="group-input-owner-name"
         error={errors.administratorName?.message}
+        debounceTimeout={0}
         {...register('administratorName', {
           required: t('Veuillez entrer votre nom.'),
         })}

--- a/apps/site/src/app/[locale]/(server)/(large)/amis/invitation/_components/InvitationForm.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/amis/invitation/_components/InvitationForm.tsx
@@ -59,6 +59,7 @@ export default function InvitationForm({
       <PrenomInput
         data-testid="member-name"
         error={errors.guestName?.message}
+        debounceTimeout={0}
         {...register('guestName', {
           required: t('Ce champ est requis.'),
         })}

--- a/apps/site/src/design-system/inputs/PrenomInput.tsx
+++ b/apps/site/src/design-system/inputs/PrenomInput.tsx
@@ -5,6 +5,7 @@ import TextInput from './TextInput'
 interface Props extends HTMLAttributes<HTMLInputElement> {
   error?: string
   value?: string
+  debounceTimeout?: number
 }
 
 export default forwardRef(function PrenomInput(

--- a/apps/site/src/design-system/inputs/TextInput.tsx
+++ b/apps/site/src/design-system/inputs/TextInput.tsx
@@ -63,6 +63,10 @@ export default forwardRef(function TextInput(
     onChange ?? (() => null),
     debounceTimeout
   )
+  // When debounceTimeout is 0, we want the value to be registered
+  // synchronously (e.g. form fields submitted right after typing).
+  const handleChange =
+    debounceTimeout > 0 ? debouncedOnChange : onChange ?? (() => null)
   return (
     <InputGroup
       name={name}
@@ -80,7 +84,7 @@ export default forwardRef(function TextInput(
         readOnly={readOnly}
         name={name}
         placeholder={placeholder}
-        onChange={debouncedOnChange}
+        onChange={handleChange}
         defaultValue={value}
         required={required}
         aria-disabled={disabled}


### PR DESCRIPTION
## Résumé

Corrige le bug **NGC-3634** — « Groupes d'amis : les noms ne sont plus enregistrés ».

### Cause racine

Pour un participant **anonyme** (navigation privée), la fin de test envoie `saveSimulation({ name: undefined })`, qui déclenche `updateGroupParticipant({ name: '' })`. Le serveur exécutait alors `createOrUpdateUser({ name: '' })` et **écrasait le nom existant** du participant avec une chaîne vide :

1. `InvitationForm` → `updateGroupParticipant({ name: guestName })` : le user est créé **avec** son nom ✓
2. Fin de test → `endTestAction(simulation, user?.name)` → `user?.name` est `undefined` (session anonyme) → `name: ''` → écrasement ✗

Confirmé par le test e2e `sees its first name in the group ranking after joining`, explicitement `skip`é depuis la refonte sécurité (ec804e964) avec le commentaire : *« Fails because updateGroupParticipant does not persist the participant name on the server side for non-admin users »*.

### Correctif

Dans `createParticipantAndUser` (`groups.repository.ts`), le champ `name` n'est plus envoyé à `createOrUpdateUser` que s'il est non vide (`user: name ? { name } : {}`) : Prisma ignore les champs `undefined` lors de l'update, donc un participant anonyme terminant son test ne peut plus effacer le nom enregistré lors du join — et sans requête DB supplémentaire.

### Validation

- Nouveau test de régression serveur : « Then it does not overwrite an existing participant name with an empty name » — échouait avant le fix (`expected '' to be 'Ed Hagenes'`), passe avec le fix. Il vérifie aussi qu'un nom non vide met toujours bien à jour le participant.
- Test e2e `sees its first name in the group ranking after joining` réactivé (plus de `test.skip`).
- Suites serveur `create-group-participant` (18) + `create-group` (19) + `users`/`simulations` (111) : toutes vertes.
- Typecheck serveur OK, Prettier/ESLint OK.

_Cette PR a été créée par un agent IA (OpenHands) au nom de Benjamin Arias._