### PR TITLE
fix(authentication): clear verification-code errors and enforce one session = one account

### DIFF
--- a/apps/server/scripts/NGC-3402-20260804.ts
+++ b/apps/server/scripts/NGC-3402-20260804.ts
@@ -1,0 +1,152 @@
+import dotenv from 'dotenv'
+import { randomUUID } from 'node:crypto'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import logger, { maskEmail } from '../src/logger.ts'
+
+dotenv.config({ quiet: true })
+
+// Imported lazily so DATABASE_URL (loaded above) is set when the Prisma
+// client is instantiated.
+const { prisma } = await import('@nosgestesclimat/core/prisma/client')
+
+/**
+ * Reassigns a unique id to every `VerifiedUser` sharing the same session id.
+ *
+ * Background: until the "one session id = one account" fix, the signup path
+ * reused the incoming session userId as `VerifiedUser.id` without any
+ * uniqueness check. `id` is not unique in the schema, so several accounts
+ * ended up attached to the same id, which later made the signin guard reject
+ * them with a 403.
+ *
+ * For each group of accounts sharing an id, one account keeps the id (the one
+ * matching the `User` row, which owns profiles/sessions, falling back to the
+ * oldest account) and the others get a fresh uuid. Their `User` rows are
+ * created and their simulations re-pointed to the new id, so FK references
+ * (`Simulation.userId`, `RefreshToken.userId`) stay consistent.
+ *
+ * Run it AFTER the auth fix is deployed (see commit "Enforce the one session
+ * userId = one account invariant"), otherwise the previous client/server can
+ * immediately recreate duplicates. It is idempotent: a second run is a no-op.
+ *
+ * Usage (from apps/server):
+ *   NODE_ENV=development node --experimental-strip-types ./scripts/NGC-3402-20260804.ts          # dry run (default)
+ *   NODE_ENV=development node --experimental-strip-types ./scripts/NGC-3402-20260804.ts --no-dry  # apply
+ */
+const findDuplicatedIdGroups = () =>
+  prisma.$queryRaw<{ id: string; count: string }[]>`
+    SELECT id, COUNT(*)::text AS count
+    FROM ngc."VerifiedUser"
+    GROUP BY id
+    HAVING COUNT(*) > 1
+  `
+
+const main = async () => {
+  const { dry } = await yargs(hideBin(process.argv))
+    .boolean('dry')
+    .alias('d', 'dry')
+    .default('dry', true)
+    .describe('dry', 'Preview the changes without applying them')
+    .parse()
+
+  try {
+    const groups = await findDuplicatedIdGroups()
+    logger.info('Found duplicated session ids', {
+      dry,
+      groups: groups.length,
+    })
+
+    let reassigned = 0
+
+    for (const { id } of groups) {
+      const verifiedUsers = await prisma.verifiedUser.findMany({
+        where: { id },
+        orderBy: { createdAt: 'asc' },
+        select: {
+          email: true,
+          name: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      })
+
+      const user = await prisma.user.findUnique({
+        where: { id },
+        select: { email: true },
+      })
+
+      // One account keeps the session id: the one matching the `User` row
+      // (profiles and refresh-token sessions reference it), falling back to
+      // the oldest account.
+      const ownerEmail =
+        verifiedUsers.find(({ email }) => email === user?.email)?.email ??
+        verifiedUsers[0]?.email
+
+      for (const verifiedUser of verifiedUsers) {
+        if (verifiedUser.email === ownerEmail) {
+          logger.info('Keeps its session id', {
+            email: maskEmail(verifiedUser.email),
+            id,
+          })
+          continue
+        }
+
+        const newId = randomUUID()
+        reassigned++
+
+        if (!dry) {
+          await prisma.$transaction(async (tx) => {
+            // `Simulation.userId` and `RefreshToken.userId` reference
+            // `User.id`; create the target row before re-pointing.
+            await tx.user.create({
+              data: {
+                id: newId,
+                email: verifiedUser.email,
+                name: verifiedUser.name,
+                createdAt: verifiedUser.createdAt,
+                updatedAt: verifiedUser.updatedAt,
+              },
+            })
+
+            await tx.simulation.updateMany({
+              where: { userId: id, userEmail: verifiedUser.email },
+              data: { userId: newId },
+            })
+
+            await tx.verifiedUser.update({
+              where: { email: verifiedUser.email },
+              data: { id: newId },
+            })
+          })
+        }
+
+        logger.info(dry ? 'Would reassign a new id' : 'Reassigned a new id', {
+          email: maskEmail(verifiedUser.email),
+          from: id,
+          to: newId,
+        })
+      }
+    }
+
+    const remaining = await prisma.$queryRaw<{ count: string }[]>`
+      SELECT COUNT(*)::text AS count
+      FROM (
+        SELECT id
+        FROM ngc."VerifiedUser"
+        GROUP BY id
+        HAVING COUNT(*) > 1
+      ) sub
+    `
+    logger.info('Finished', {
+      dry,
+      reassigned,
+      remainingDuplicatedIds: remaining[0]?.count ?? '0',
+    })
+    process.exit(0)
+  } catch (error) {
+    logger.error(error)
+    process.exit(1)
+  }
+}
+
+main()

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -88,7 +88,7 @@ describe('Given a NGC user', () => {
     })
 
     describe('And verification code does not exist', () => {
-      test(`Then it returns a ${StatusCodes.UNAUTHORIZED} error`, async () => {
+      test(`Then it returns a ${StatusCodes.UNAUTHORIZED} error telling no code was requested`, async () => {
         await agent
           .post(url)
           .send({
@@ -97,6 +97,7 @@ describe('Given a NGC user', () => {
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
           })
           .expect(StatusCodes.UNAUTHORIZED)
+          .expect({ rejection: 'never_requested' })
       })
 
       test('Then it logs a rejection telling no code was requested', async () => {
@@ -273,7 +274,7 @@ describe('Given a NGC user', () => {
       })
 
       describe('And is expired', () => {
-        test(`Then it returns a ${StatusCodes.UNAUTHORIZED} error`, async () => {
+        test(`Then it returns a ${StatusCodes.UNAUTHORIZED} error telling the code expired`, async () => {
           const verificationCode = await createVerificationCode({
             agent,
             expirationDate: dayjs().subtract(1, 'second').toDate(),
@@ -287,6 +288,7 @@ describe('Given a NGC user', () => {
               userId: faker.string.uuid(),
             })
             .expect(StatusCodes.UNAUTHORIZED)
+            .expect({ rejection: 'expired' })
         })
 
         test('Then it logs an expired rejection', async () => {

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -604,6 +604,30 @@ describe('Given a NGC user', () => {
             })
           )
         })
+
+        test(`Then signing up a new email with the same userId returns a ${StatusCodes.FORBIDDEN} error and does not create an account`, async () => {
+          const emailC = faker.internet.email().toLocaleLowerCase()
+          const signUpCodeC = await createVerificationCode({
+            agent,
+            verificationCode: { email: emailC },
+            mode: VerificationCodeMode.signUp,
+          })
+
+          await agent
+            .post(url)
+            .send({
+              userId: userIdA,
+              email: signUpCodeC.email,
+              code: signUpCodeC.code,
+            })
+            .expect(StatusCodes.FORBIDDEN)
+
+          const createdUser = await prisma.verifiedUser.findUnique({
+            where: { email: emailC },
+          })
+
+          expect(createdUser).toBeNull()
+        })
       })
     })
 

--- a/apps/server/src/features/authentication/authentication.controller.ts
+++ b/apps/server/src/features/authentication/authentication.controller.ts
@@ -93,7 +93,11 @@ router
             extra: rejected,
           })
 
-          return res.status(StatusCodes.UNAUTHORIZED).end()
+          // Expose *why* the code was rejected so the client can tell an
+          // expired code ("ask for a new one") apart from a wrong one.
+          return res
+            .status(StatusCodes.UNAUTHORIZED)
+            .json({ rejection: err.rejection })
         }
 
         if (err instanceof EntityNotFoundException) {

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -175,25 +175,28 @@ export async function createAccountOrSignin(loginDto: LoginDto) {
       { session }
     )
 
-    if (existingUser) {
-      // Reject login if the anonymous session userId is already attached
-      // to a different verified account
-      if (existingUser.id !== loginDto.userId) {
-        const conflictingUser = await session.verifiedUser.findFirst({
-          where: {
-            id: loginDto.userId,
-            NOT: { email: loginDto.email },
-          },
-          select: { email: true },
-        })
+    // A session userId must map to at most one verified account. Reusing a
+    // userId already attached to a different verified account would silently
+    // create duplicate accounts sharing the same id on signup (the `id`
+    // column of VerifiedUser is not unique), and is already rejected on
+    // signin. Enforce the invariant on both paths.
+    if (existingUser?.id !== loginDto.userId) {
+      const conflictingUser = await session.verifiedUser.findFirst({
+        where: {
+          id: loginDto.userId,
+          NOT: { email: loginDto.email },
+        },
+        select: { email: true },
+      })
 
-        if (conflictingUser) {
-          throw new ForbiddenException(
-            'userId is already attached to another verified account'
-          )
-        }
+      if (conflictingUser) {
+        throw new ForbiddenException(
+          'userId is already attached to another verified account'
+        )
       }
+    }
 
+    if (existingUser) {
       return [existingUser, VerificationCodeMode.signIn] as const
     }
 

--- a/apps/site/src/components/authentication/__tests__/authMachine.test.ts
+++ b/apps/site/src/components/authentication/__tests__/authMachine.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import { authReducer } from '../authMachine'
-import { invalidCodeError, rateLimitedError, unknownCodeError } from '../errors'
+import {
+  invalidCodeError,
+  rateLimitedError,
+  unknownCodeError,
+  type Translate,
+} from '../errors'
 import type { AuthEvent, AuthPhase } from '../types'
+
+const t = ((key: string, defaultValue?: string) =>
+  defaultValue ?? '') as Translate
 
 const pending = {
   email: 'user@example.com',
@@ -83,12 +91,12 @@ describe('authReducer', () => {
     it('ignores all non-SUBMIT_EMAIL events and stays idle', () => {
       const ignoredEvents: AuthEvent[] = [
         { type: 'EMAIL_SENT', pending, cooldownUntil: cooldown },
-        { type: 'EMAIL_ERROR', reason: unknownCodeError() },
+        { type: 'EMAIL_ERROR', reason: unknownCodeError(t) },
         { type: 'CODE_VALID', userId: 'u1' },
-        { type: 'CODE_INVALID', reason: invalidCodeError() },
+        { type: 'CODE_INVALID', reason: invalidCodeError(t) },
         { type: 'RESEND_CODE' },
         { type: 'CODE_RESENT', pending, cooldownUntil: cooldown },
-        { type: 'CODE_RESEND_ERROR', reason: unknownCodeError() },
+        { type: 'CODE_RESEND_ERROR', reason: unknownCodeError(t) },
         { type: 'GO_BACK' },
         { type: 'CLEAR_CODE_ERROR' },
       ]
@@ -124,11 +132,11 @@ describe('authReducer', () => {
     it('returns to idle on EMAIL_ERROR', () => {
       const result = authReducer(state, {
         type: 'EMAIL_ERROR',
-        reason: rateLimitedError(),
+        reason: rateLimitedError(t),
       })
       expect(result).toEqual({
         phase: 'idle',
-        emailError: rateLimitedError(),
+        emailError: rateLimitedError(t),
       })
     })
 
@@ -172,13 +180,13 @@ describe('authReducer', () => {
     it('sets isResending on RESEND_CODE and clears resendError', () => {
       const withError = {
         ...state,
-        resendError: unknownCodeError(),
-        codeError: invalidCodeError(),
+        resendError: unknownCodeError(t),
+        codeError: invalidCodeError(t),
       }
       const result = authReducer(withError, { type: 'RESEND_CODE' })
       expect((result as typeof withError).isResending).toBe(true)
       expect((result as typeof withError).resendError).toBeNull()
-      expect((result as typeof withError).codeError).toEqual(invalidCodeError())
+      expect((result as typeof withError).codeError).toEqual(invalidCodeError(t))
     })
 
     it('returns to code_sent with new pending on CODE_RESENT', () => {
@@ -206,16 +214,16 @@ describe('authReducer', () => {
       const resending = { ...state, isResending: true }
       const result = authReducer(resending, {
         type: 'CODE_RESEND_ERROR',
-        reason: rateLimitedError(),
+        reason: rateLimitedError(t),
       })
       expect((result as typeof resending).isResending).toBe(false)
       expect((result as typeof resending).resendError).toEqual(
-        rateLimitedError()
+        rateLimitedError(t)
       )
     })
 
     it('clears codeError on CLEAR_CODE_ERROR', () => {
-      const withError = { ...state, codeError: invalidCodeError() }
+      const withError = { ...state, codeError: invalidCodeError(t) }
       const result = authReducer(withError, { type: 'CLEAR_CODE_ERROR' })
       expect((result as typeof withError).codeError).toBeNull()
     })
@@ -269,7 +277,7 @@ describe('authReducer', () => {
     it('returns to code_sent with codeError on CODE_INVALID', () => {
       const result = authReducer(state, {
         type: 'CODE_INVALID',
-        reason: invalidCodeError(),
+        reason: invalidCodeError(t),
       })
       expect(result).toEqual({
         phase: 'code_sent',
@@ -277,7 +285,7 @@ describe('authReducer', () => {
         pending,
         cooldownUntil: cooldown,
         isResending: false,
-        codeError: invalidCodeError(),
+        codeError: invalidCodeError(t),
         resendError: null,
       })
     })

--- a/apps/site/src/components/authentication/__tests__/authMachine.test.ts
+++ b/apps/site/src/components/authentication/__tests__/authMachine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { authReducer } from '../authMachine'
-import { InvalidCodeError, RateLimitedError, UnknownCodeError } from '../errors'
+import { invalidCodeError, rateLimitedError, unknownCodeError } from '../errors'
 import type { AuthEvent, AuthPhase } from '../types'
 
 const pending = {
@@ -83,12 +83,12 @@ describe('authReducer', () => {
     it('ignores all non-SUBMIT_EMAIL events and stays idle', () => {
       const ignoredEvents: AuthEvent[] = [
         { type: 'EMAIL_SENT', pending, cooldownUntil: cooldown },
-        { type: 'EMAIL_ERROR', reason: new UnknownCodeError() },
+        { type: 'EMAIL_ERROR', reason: unknownCodeError() },
         { type: 'CODE_VALID', userId: 'u1' },
-        { type: 'CODE_INVALID', reason: new InvalidCodeError() },
+        { type: 'CODE_INVALID', reason: invalidCodeError() },
         { type: 'RESEND_CODE' },
         { type: 'CODE_RESENT', pending, cooldownUntil: cooldown },
-        { type: 'CODE_RESEND_ERROR', reason: new UnknownCodeError() },
+        { type: 'CODE_RESEND_ERROR', reason: unknownCodeError() },
         { type: 'GO_BACK' },
         { type: 'CLEAR_CODE_ERROR' },
       ]
@@ -124,11 +124,11 @@ describe('authReducer', () => {
     it('returns to idle on EMAIL_ERROR', () => {
       const result = authReducer(state, {
         type: 'EMAIL_ERROR',
-        reason: new RateLimitedError(),
+        reason: rateLimitedError(),
       })
       expect(result).toEqual({
         phase: 'idle',
-        emailError: new RateLimitedError(),
+        emailError: rateLimitedError(),
       })
     })
 
@@ -172,15 +172,13 @@ describe('authReducer', () => {
     it('sets isResending on RESEND_CODE and clears resendError', () => {
       const withError = {
         ...state,
-        resendError: new UnknownCodeError(),
-        codeError: new InvalidCodeError(),
+        resendError: unknownCodeError(),
+        codeError: invalidCodeError(),
       }
       const result = authReducer(withError, { type: 'RESEND_CODE' })
       expect((result as typeof withError).isResending).toBe(true)
       expect((result as typeof withError).resendError).toBeNull()
-      expect((result as typeof withError).codeError).toEqual(
-        new InvalidCodeError()
-      )
+      expect((result as typeof withError).codeError).toEqual(invalidCodeError())
     })
 
     it('returns to code_sent with new pending on CODE_RESENT', () => {
@@ -208,16 +206,16 @@ describe('authReducer', () => {
       const resending = { ...state, isResending: true }
       const result = authReducer(resending, {
         type: 'CODE_RESEND_ERROR',
-        reason: new RateLimitedError(),
+        reason: rateLimitedError(),
       })
       expect((result as typeof resending).isResending).toBe(false)
       expect((result as typeof resending).resendError).toEqual(
-        new RateLimitedError()
+        rateLimitedError()
       )
     })
 
     it('clears codeError on CLEAR_CODE_ERROR', () => {
-      const withError = { ...state, codeError: new InvalidCodeError() }
+      const withError = { ...state, codeError: invalidCodeError() }
       const result = authReducer(withError, { type: 'CLEAR_CODE_ERROR' })
       expect((result as typeof withError).codeError).toBeNull()
     })
@@ -271,7 +269,7 @@ describe('authReducer', () => {
     it('returns to code_sent with codeError on CODE_INVALID', () => {
       const result = authReducer(state, {
         type: 'CODE_INVALID',
-        reason: new InvalidCodeError(),
+        reason: invalidCodeError(),
       })
       expect(result).toEqual({
         phase: 'code_sent',
@@ -279,7 +277,7 @@ describe('authReducer', () => {
         pending,
         cooldownUntil: cooldown,
         isResending: false,
-        codeError: new InvalidCodeError(),
+        codeError: invalidCodeError(),
         resendError: null,
       })
     })

--- a/apps/site/src/components/authentication/__tests__/errors.test.ts
+++ b/apps/site/src/components/authentication/__tests__/errors.test.ts
@@ -1,6 +1,11 @@
 import { failure } from '@nosgestesclimat/core/lib/result'
 import { describe, expect, it } from 'vitest'
-import { invalidCodeError, rateLimitedError, unknownCodeError } from '../errors'
+import {
+  expiredCodeError,
+  invalidCodeError,
+  rateLimitedError,
+  unknownCodeError,
+} from '../errors'
 
 // Regression test: auth server actions return `Result` objects to client
 // components through React Flight. React Flight cannot serialize `Error`
@@ -10,6 +15,7 @@ import { invalidCodeError, rateLimitedError, unknownCodeError } from '../errors'
 // therefore stay plain, JSON-serializable objects.
 describe('auth error payloads', () => {
   it.each([
+    ['expiredCodeError', expiredCodeError],
     ['invalidCodeError', invalidCodeError],
     ['rateLimitedError', rateLimitedError],
     ['unknownCodeError', unknownCodeError],

--- a/apps/site/src/components/authentication/__tests__/errors.test.ts
+++ b/apps/site/src/components/authentication/__tests__/errors.test.ts
@@ -1,6 +1,7 @@
 import { failure } from '@nosgestesclimat/core/lib/result'
 import { describe, expect, it } from 'vitest'
 import {
+  accountConflictError,
   expiredCodeError,
   invalidCodeError,
   rateLimitedError,
@@ -17,6 +18,7 @@ describe('auth error payloads', () => {
   it.each([
     ['expiredCodeError', expiredCodeError],
     ['invalidCodeError', invalidCodeError],
+    ['accountConflictError', accountConflictError],
     ['rateLimitedError', rateLimitedError],
     ['unknownCodeError', unknownCodeError],
   ] as const)(

--- a/apps/site/src/components/authentication/__tests__/errors.test.ts
+++ b/apps/site/src/components/authentication/__tests__/errors.test.ts
@@ -1,0 +1,37 @@
+import { failure } from '@nosgestesclimat/core/lib/result'
+import { describe, expect, it } from 'vitest'
+import { invalidCodeError, rateLimitedError, unknownCodeError } from '../errors'
+
+// Regression test: auth server actions return `Result` objects to client
+// components through React Flight. React Flight cannot serialize `Error`
+// instances (custom properties like `code` are dropped, and it logs
+// "Only plain objects can be passed to Client Components from Server
+// Components. Error objects are not supported."). The error payloads must
+// therefore stay plain, JSON-serializable objects.
+describe('auth error payloads', () => {
+  it.each([
+    ['invalidCodeError', invalidCodeError],
+    ['rateLimitedError', rateLimitedError],
+    ['unknownCodeError', unknownCodeError],
+  ] as const)(
+    '%s returns a plain object, not an Error instance',
+    (_name, factory) => {
+      const error = factory()
+
+      expect(error).not.toBeInstanceOf(Error)
+      expect(Object.getPrototypeOf(error)).toBe(Object.prototype)
+      // The error must survive the server/client wire round-trip with its
+      // discriminator intact.
+      expect(JSON.parse(JSON.stringify(error))).toEqual(error)
+    }
+  )
+
+  it('keeps the code after the whole failure Result is serialized', () => {
+    const result = failure(invalidCodeError())
+
+    expect(JSON.parse(JSON.stringify(result))).toEqual({
+      success: false,
+      error: { code: 'invalid', message: 'Code invalide' },
+    })
+  })
+})

--- a/apps/site/src/components/authentication/__tests__/errors.test.ts
+++ b/apps/site/src/components/authentication/__tests__/errors.test.ts
@@ -6,6 +6,7 @@ import {
   invalidCodeError,
   rateLimitedError,
   unknownCodeError,
+  type Translate,
 } from '../errors'
 
 // Regression test: auth server actions return `Result` objects to client
@@ -14,6 +15,9 @@ import {
 // "Only plain objects can be passed to Client Components from Server
 // Components. Error objects are not supported."). The error payloads must
 // therefore stay plain, JSON-serializable objects.
+const t = ((key: string, defaultValue?: string) =>
+  defaultValue ?? '') as Translate
+
 describe('auth error payloads', () => {
   it.each([
     ['expiredCodeError', expiredCodeError],
@@ -24,7 +28,7 @@ describe('auth error payloads', () => {
   ] as const)(
     '%s returns a plain object, not an Error instance',
     (_name, factory) => {
-      const error = factory()
+      const error = factory(t)
 
       expect(error).not.toBeInstanceOf(Error)
       expect(Object.getPrototypeOf(error)).toBe(Object.prototype)
@@ -35,7 +39,7 @@ describe('auth error payloads', () => {
   )
 
   it('keeps the code after the whole failure Result is serialized', () => {
-    const result = failure(invalidCodeError())
+    const result = failure(invalidCodeError(t))
 
     expect(JSON.parse(JSON.stringify(result))).toEqual({
       success: false,

--- a/apps/site/src/components/authentication/_hooks/useAuthEffects.ts
+++ b/apps/site/src/components/authentication/_hooks/useAuthEffects.ts
@@ -10,7 +10,7 @@ import { safeSessionStorage } from '@/utils/browser/safeSessionStorage'
 import { captureException } from '@sentry/nextjs'
 import { useRouter } from 'next/navigation'
 
-import { UnknownCodeError } from '../errors'
+import { unknownCodeError } from '../errors'
 import type {
   AuthEvent,
   AuthPhase,
@@ -44,7 +44,7 @@ function useVerifyEffect(
       })
       .catch((error) => {
         captureException(error)
-        dispatch({ type: 'CODE_INVALID', reason: new UnknownCodeError() })
+        dispatch({ type: 'CODE_INVALID', reason: unknownCodeError() })
       })
 
     return () => {

--- a/apps/site/src/components/authentication/_hooks/useAuthEffects.ts
+++ b/apps/site/src/components/authentication/_hooks/useAuthEffects.ts
@@ -5,12 +5,13 @@ import { useEffect, type Dispatch } from 'react'
 import { useCookieManagement } from '@/components/cookies/useCookieManagement'
 import { EMAIL_PENDING_AUTHENTICATION_KEY } from '@/constants/authentication/sessionStorage'
 import { reconcileUserOnAuth } from '@/helpers/user/reconcileOnAuth'
+import { useClientTranslation } from '@/hooks/useClientTranslation'
 import { trackPosthogEvent } from '@/utils/analytics/trackEvent'
 import { safeSessionStorage } from '@/utils/browser/safeSessionStorage'
 import { captureException } from '@sentry/nextjs'
 import { useRouter } from 'next/navigation'
 
-import { unknownCodeError } from '../errors'
+import { unknownCodeError, type Translate } from '../errors'
 import type {
   AuthEvent,
   AuthPhase,
@@ -22,7 +23,8 @@ import type {
 function useVerifyEffect(
   state: AuthPhase,
   dispatch: Dispatch<AuthEvent>,
-  verify: VerifyStrategy
+  verify: VerifyStrategy,
+  t: Translate
 ) {
   const verificationEmail =
     state.phase === 'verifying_code' ? state.pending.email : null
@@ -44,13 +46,13 @@ function useVerifyEffect(
       })
       .catch((error) => {
         captureException(error)
-        dispatch({ type: 'CODE_INVALID', reason: unknownCodeError() })
+        dispatch({ type: 'CODE_INVALID', reason: unknownCodeError(t) })
       })
 
     return () => {
       cancelled = true
     }
-  }, [verificationEmail, verificationCode, verify, dispatch])
+  }, [verificationEmail, verificationCode, verify, dispatch, t])
 }
 
 function useCompletionEffect(
@@ -125,6 +127,7 @@ export function useAuthEffects({
   redirectPathname,
   tracker,
 }: UseAuthEffectsOptions) {
-  useVerifyEffect(state, dispatch, verify)
+  const { t } = useClientTranslation()
+  useVerifyEffect(state, dispatch, verify, t)
   useCompletionEffect(state, { onComplete, redirectPathname, tracker })
 }

--- a/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
+++ b/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
@@ -119,7 +119,7 @@ export default function VerificationCodeForm() {
             )
             .with('unknown', () =>
               t(
-                'common.errors.errorHappening',
+                'common.errors.errorHappened',
                 'Une erreur est survenue. Veuillez réessayer.'
               )
             )

--- a/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
+++ b/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
@@ -102,6 +102,12 @@ export default function VerificationCodeForm() {
                 'Ce code a expiré. Demandez un nouveau code et utilisez-le dans l\u2019heure qui suit.'
               )
             )
+            .with('account_conflict', () =>
+              t(
+                'signIn.code.accountConflict',
+                'Cette session est déjà associée à un autre compte. Déconnectez-vous puis réessayez avec une nouvelle session.'
+              )
+            )
             .with('invalid', () =>
               t('signIn.code.invalid', 'Le code est invalide')
             )

--- a/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
+++ b/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
@@ -1,14 +1,20 @@
 'use client'
 
+import { useAuth } from '@/components/authentication/AuthProvider'
 import CheckCircleIcon from '@/components/icons/status/CheckCircleIcon'
 import Trans from '@/components/translation/trans/TransClient'
 import Button from '@/design-system/buttons/Button'
 import { defaultInputStyleClassNames } from '@/design-system/inputs/TextInput'
 import Loader from '@/design-system/layout/Loader'
-import { type ChangeEvent, type FormEvent, useCallback, useId, useState } from 'react'
-import { twMerge } from 'tailwind-merge'
-import { useAuth } from '@/components/authentication/AuthProvider'
 import { useClientTranslation } from '@/hooks/useClientTranslation'
+import {
+  type ChangeEvent,
+  type FormEvent,
+  useCallback,
+  useId,
+  useState,
+} from 'react'
+import { twMerge } from 'tailwind-merge'
 import { match } from 'ts-pattern'
 
 export default function VerificationCodeForm() {
@@ -29,7 +35,12 @@ export default function VerificationCodeForm() {
   const handleSubmit = useCallback(
     (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault()
-      if (state.phase === 'code_sent' && code.length === 6 && !state.isResending && !state.codeError) {
+      if (
+        state.phase === 'code_sent' &&
+        code.length === 6 &&
+        !state.isResending &&
+        !state.codeError
+      ) {
         submitCode(code)
       }
     },
@@ -60,29 +71,53 @@ export default function VerificationCodeForm() {
         value={code}
         onChange={handleChange}
         disabled={state.phase !== 'code_sent' || state.isResending}
-        aria-invalid={state.phase === 'code_sent' && !!state.codeError ? 'true' : 'false'}
+        aria-invalid={
+          state.phase === 'code_sent' && !!state.codeError ? 'true' : 'false'
+        }
         placeholder="000000"
         className={twMerge(
-          'w-full max-w-120 bg-white! dark:text-default! p-4 text-2xl tracking-widest',
+          'dark:text-default! w-full max-w-120 bg-white! p-4 text-2xl tracking-widest',
           defaultInputStyleClassNames,
           state.phase === 'code_sent' && state.codeError
-            ? 'border-red-200! bg-red-50! ring-2 ring-red-700!' : '',
+            ? 'border-red-200! bg-red-50! ring-2 ring-red-700!'
+            : '',
           state.phase === 'authenticated'
-            ? 'border-green-700! ring-2 ring-green-700!' : '',
-          (state.phase !== 'code_sent' || state.isResending)
-            ? 'cursor-not-allowed' : '',
+            ? 'border-green-700! ring-2 ring-green-700!'
+            : '',
+          state.phase !== 'code_sent' || state.isResending
+            ? 'cursor-not-allowed'
+            : '',
           'focus:ring-primary-700 focus:ring-2 focus:ring-offset-3 focus:outline-hidden'
         )}
       />
 
       {state.phase === 'code_sent' && state.codeError && (
-        <p id="verification-error" className="mt-2 text-sm text-red-800 dark:text-white">
+        <p
+          id="verification-error"
+          className="mt-2 text-sm text-red-800 dark:text-white">
           {match(state.codeError.code)
-            .with('invalid', () => t('signIn.code.invalid', 'Le code est invalide'))
-            .with('rate_limited', () => t('signIn.code.rateLimited', 'Veuillez patienter un instant avant de réessayer.'))
-            .with('unknown', () => t('common.errors.errorHappening', 'Une erreur est survenue. Veuillez réessayer.'))
-            .exhaustive()
-          }
+            .with('expired', () =>
+              t(
+                'signIn.code.expired',
+                'Ce code a expiré. Demandez un nouveau code et utilisez-le dans l\u2019heure qui suit.'
+              )
+            )
+            .with('invalid', () =>
+              t('signIn.code.invalid', 'Le code est invalide')
+            )
+            .with('rate_limited', () =>
+              t(
+                'signIn.code.rateLimited',
+                'Veuillez patienter un instant avant de réessayer.'
+              )
+            )
+            .with('unknown', () =>
+              t(
+                'common.errors.errorHappening',
+                'Une erreur est survenue. Veuillez réessayer.'
+              )
+            )
+            .exhaustive()}
         </p>
       )}
 
@@ -90,26 +125,45 @@ export default function VerificationCodeForm() {
         <Button
           type="submit"
           className="mt-4"
-          disabled={code.length !== 6 || state.isResending || state.codeError !== null}
+          disabled={
+            code.length !== 6 || state.isResending || state.codeError !== null
+          }
           data-testid="verification-code-submit-button">
-          <Trans i18nKey="signIn.verificationForm.submitButton">Valider mon code</Trans>
+          <Trans i18nKey="signIn.verificationForm.submitButton">
+            Valider mon code
+          </Trans>
         </Button>
       )}
 
       {state.phase === 'verifying_code' && (
-        <div id="verification-status" role="status" aria-live="polite"
+        <div
+          id="verification-status"
+          role="status"
+          aria-live="polite"
           className="mt-2 flex items-baseline gap-2 pl-2 text-xs">
           <Loader color="dark" size="sm" />
-          <span><Trans i18nKey="signIn.verificationForm.pending">Nous vérifions votre code...</Trans></span>
+          <span>
+            <Trans i18nKey="signIn.verificationForm.pending">
+              Nous vérifions votre code...
+            </Trans>
+          </span>
         </div>
       )}
 
       {state.phase === 'authenticated' && (
-        <div id="verification-status" role="status" aria-live="polite"
+        <div
+          id="verification-status"
+          role="status"
+          aria-live="polite"
           className="mt-4 flex items-baseline gap-2 text-sm">
-          <CheckCircleIcon className="h-4 w-4 fill-green-700 dark:fill-green-100" aria-hidden="true" />
+          <CheckCircleIcon
+            className="h-4 w-4 fill-green-700 dark:fill-green-100"
+            aria-hidden="true"
+          />
           <span className="text-green-700 dark:text-green-100">
-            <Trans i18nKey="signIn.verificationForm.success">Votre code est valide !</Trans>
+            <Trans i18nKey="signIn.verificationForm.success">
+              Votre code est valide !
+            </Trans>
           </span>
         </div>
       )}

--- a/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/__tests__/NotReceived.test.tsx
+++ b/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/__tests__/NotReceived.test.tsx
@@ -1,12 +1,14 @@
+import type { AuthContextValue } from '@/components/authentication/AuthProvider'
+import { useAuth } from '@/components/authentication/AuthProvider'
+import { unknownCodeError } from '@/components/authentication/errors'
 import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useAuth } from '@/components/authentication/AuthProvider'
-import type { AuthContextValue } from '@/components/authentication/AuthProvider'
-import { UnknownCodeError } from '@/components/authentication/errors'
 import NotReceived from '../NotReceived'
 
 vi.mock('@/components/authentication/AuthProvider', async () => {
-  const actual = await vi.importActual('@/components/authentication/AuthProvider')
+  const actual = await vi.importActual(
+    '@/components/authentication/AuthProvider'
+  )
   return { ...actual, useAuth: vi.fn() }
 })
 vi.mock('@/components/authentication/_hooks/useSecondsLeft', () => ({
@@ -64,7 +66,7 @@ describe('NotReceived', () => {
         cooldownUntil: 0,
         isResending: false,
         codeError: null,
-        resendError: new UnknownCodeError(),
+        resendError: unknownCodeError(),
       },
     } as AuthContextValue)
 

--- a/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/__tests__/NotReceived.test.tsx
+++ b/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/__tests__/NotReceived.test.tsx
@@ -1,9 +1,15 @@
 import type { AuthContextValue } from '@/components/authentication/AuthProvider'
 import { useAuth } from '@/components/authentication/AuthProvider'
-import { unknownCodeError } from '@/components/authentication/errors'
+import {
+  unknownCodeError,
+  type Translate,
+} from '@/components/authentication/errors'
 import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import NotReceived from '../NotReceived'
+
+const t = ((key: string, defaultValue?: string) =>
+  defaultValue ?? '') as Translate
 
 vi.mock('@/components/authentication/AuthProvider', async () => {
   const actual = await vi.importActual(
@@ -66,7 +72,7 @@ describe('NotReceived', () => {
         cooldownUntil: 0,
         isResending: false,
         codeError: null,
-        resendError: unknownCodeError(),
+        resendError: unknownCodeError(t),
       },
     } as AuthContextValue)
 

--- a/apps/site/src/components/authentication/errors.ts
+++ b/apps/site/src/components/authentication/errors.ts
@@ -9,6 +9,7 @@
 export type CodeError =
   | { code: 'expired'; message: string }
   | { code: 'invalid'; message: string }
+  | { code: 'account_conflict'; message: string }
   | { code: 'rate_limited'; message: string }
   | { code: 'unknown'; message: string }
 
@@ -19,6 +20,16 @@ export type EmailError =
 export const expiredCodeError = (): CodeError => ({
   code: 'expired',
   message: 'Le code a expiré',
+})
+
+/**
+ * The server rejected the login because the current session (anonymous user
+ * id) is already attached to another verified account. The user must start a
+ * fresh session (log out / clear cookies) before logging in with this email.
+ */
+export const accountConflictError = (): CodeError => ({
+  code: 'account_conflict',
+  message: 'Session déjà associée à un autre compte',
 })
 
 export const invalidCodeError = (): CodeError => ({

--- a/apps/site/src/components/authentication/errors.ts
+++ b/apps/site/src/components/authentication/errors.ts
@@ -1,23 +1,31 @@
-import { DomainError } from '@nosgestesclimat/core/lib/errors'
+/**
+ * Errors returned by auth server actions.
+ *
+ * These must stay plain serializable objects: server actions (`'use server'`)
+ * return them to client components through React Flight, which cannot
+ * serialize `Error` instances (custom properties like `code` are dropped and
+ * a "Error objects are not supported" warning is emitted).
+ */
+export type CodeError =
+  | { code: 'invalid'; message: string }
+  | { code: 'rate_limited'; message: string }
+  | { code: 'unknown'; message: string }
 
-export class InvalidCodeError extends DomainError<'invalid'> {
-  constructor() {
-    super('invalid', 'Code invalide')
-  }
-}
+export type EmailError =
+  | { code: 'rate_limited'; message: string }
+  | { code: 'unknown'; message: string }
 
-export class RateLimitedError extends DomainError<'rate_limited'> {
-  constructor() {
-    super('rate_limited', 'Trop de requêtes')
-  }
-}
+export const invalidCodeError = (): CodeError => ({
+  code: 'invalid',
+  message: 'Code invalide',
+})
 
-export class UnknownCodeError extends DomainError<'unknown'> {
-  constructor() {
-    super('unknown', 'Erreur inconnue')
-  }
-}
+export const rateLimitedError = (): EmailError => ({
+  code: 'rate_limited',
+  message: 'Trop de requêtes',
+})
 
-export type CodeError = InvalidCodeError | RateLimitedError | UnknownCodeError
-
-export type EmailError = RateLimitedError | UnknownCodeError
+export const unknownCodeError = (): EmailError => ({
+  code: 'unknown',
+  message: 'Erreur inconnue',
+})

--- a/apps/site/src/components/authentication/errors.ts
+++ b/apps/site/src/components/authentication/errors.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from 'i18next'
+
 /**
  * Errors returned by auth server actions.
  *
@@ -17,9 +19,11 @@ export type EmailError =
   | { code: 'rate_limited'; message: string }
   | { code: 'unknown'; message: string }
 
-export const expiredCodeError = (): CodeError => ({
+export type Translate = TFunction
+
+export const expiredCodeError = (t: Translate): CodeError => ({
   code: 'expired',
-  message: 'Le code a expiré',
+  message: t('signIn.code.expired', 'Le code a expiré'),
 })
 
 /**
@@ -27,22 +31,25 @@ export const expiredCodeError = (): CodeError => ({
  * id) is already attached to another verified account. The user must start a
  * fresh session (log out / clear cookies) before logging in with this email.
  */
-export const accountConflictError = (): CodeError => ({
+export const accountConflictError = (t: Translate): CodeError => ({
   code: 'account_conflict',
-  message: 'Session déjà associée à un autre compte',
+  message: t(
+    'signIn.code.accountConflict',
+    'Session déjà associée à un autre compte'
+  ),
 })
 
-export const invalidCodeError = (): CodeError => ({
+export const invalidCodeError = (t: Translate): CodeError => ({
   code: 'invalid',
-  message: 'Code invalide',
+  message: t('signIn.code.invalid', 'Code invalide'),
 })
 
-export const rateLimitedError = (): EmailError => ({
+export const rateLimitedError = (t: Translate): EmailError => ({
   code: 'rate_limited',
-  message: 'Trop de requêtes',
+  message: t('signIn.code.rateLimited', 'Trop de requêtes'),
 })
 
-export const unknownCodeError = (): EmailError => ({
+export const unknownCodeError = (t: Translate): EmailError => ({
   code: 'unknown',
-  message: 'Erreur inconnue',
+  message: t('common.errors.errorHappened', 'Erreur inconnue'),
 })

--- a/apps/site/src/components/authentication/errors.ts
+++ b/apps/site/src/components/authentication/errors.ts
@@ -7,6 +7,7 @@
  * a "Error objects are not supported" warning is emitted).
  */
 export type CodeError =
+  | { code: 'expired'; message: string }
   | { code: 'invalid'; message: string }
   | { code: 'rate_limited'; message: string }
   | { code: 'unknown'; message: string }
@@ -14,6 +15,11 @@ export type CodeError =
 export type EmailError =
   | { code: 'rate_limited'; message: string }
   | { code: 'unknown'; message: string }
+
+export const expiredCodeError = (): CodeError => ({
+  code: 'expired',
+  message: 'Le code a expiré',
+})
 
 export const invalidCodeError = (): CodeError => ({
   code: 'invalid',

--- a/apps/site/src/helpers/server/error.ts
+++ b/apps/site/src/helpers/server/error.ts
@@ -15,8 +15,12 @@ export class NoSessionFoundError extends APIError {
 }
 
 export class UnauthorizedError extends APIError {
-  constructor() {
-    super('Unauthorized')
+  /**
+   * Why a verification-code login was rejected, when the server tells us.
+   * @see InvalidVerificationCodeException on the server
+   */
+  constructor(public rejection?: 'expired' | 'mismatch' | 'never_requested') {
+    super(rejection ? `Unauthorized (${rejection})` : 'Unauthorized')
     this.name = 'UnauthorizedError'
   }
 }

--- a/apps/site/src/helpers/shared/handleApiResponse.ts
+++ b/apps/site/src/helpers/shared/handleApiResponse.ts
@@ -35,8 +35,21 @@ export async function handleApiResponse<T>(response: Response): Promise<T> {
     switch (response.status) {
       case 404:
         throw new NotFoundError()
-      case 401:
-        throw new UnauthorizedError()
+      case 401: {
+        const rejection =
+          parsedBody &&
+          typeof parsedBody === 'object' &&
+          'rejection' in parsedBody
+            ? parsedBody.rejection
+            : undefined
+        throw new UnauthorizedError(
+          rejection === 'expired' ||
+            rejection === 'mismatch' ||
+            rejection === 'never_requested'
+            ? rejection
+            : undefined
+        )
+      }
       case 403:
         throw new ForbiddenError()
       case 429:

--- a/apps/site/src/locales/ui/ui-en.yaml
+++ b/apps/site/src/locales/ui/ui-en.yaml
@@ -1419,6 +1419,10 @@ entries:
   signIn.emailForm.error.invalid: The email address is invalid
   signIn.emailForm.error.rateLimited: A code has already been sent to this address. Please wait before requesting a new one.
   signIn.code.rateLimited: Please wait a moment before trying again.
+  signIn.code.invalid: The code is invalid
+  signIn.code.expired: This code has expired. Request a new code and use it within the hour.
+  signIn.code.accountConflict: This session is already associated with another account. Please log out and try again with a new session.
+  common.errors.errorHappened: An error has occurred. Please try again.
   results.objective.under4.description.body: With the work of the government and society as a whole over the coming years, your footprint should naturally fall to around 2 tonnes.
   results.objective.under4.description.body.lock: Avec le travail de l’État et toute la société dans les années à venir, votre empreinte devrait naturellement diminuer pour se rapprocher des 2 tonnes.
   Part de la sous-catégorie {{percentage}}: Share of sub-category {{percentage}}

--- a/apps/site/src/locales/ui/ui-fr.yaml
+++ b/apps/site/src/locales/ui/ui-fr.yaml
@@ -1446,3 +1446,5 @@ entries:
   signIn.code.rateLimited: Veuillez patienter un instant avant de réessayer.
   common.errors.errorHappened: Une erreur est survenue. Veuillez réessayer.
   signIn.code.invalid: Le code est invalide
+  signIn.code.expired: Ce code a expiré. Demandez un nouveau code et utilisez-le dans l’heure qui suit.
+  signIn.code.accountConflict: Cette session est déjà associée à un autre compte. Déconnectez-vous puis réessayez avec une nouvelle session.

--- a/apps/site/src/services/auth/create-verification-code.ts
+++ b/apps/site/src/services/auth/create-verification-code.ts
@@ -4,8 +4,11 @@ import {
   rateLimitedError,
   unknownCodeError,
   type EmailError,
+  type Translate,
 } from '@/components/authentication/errors'
 import { VERIFICATION_CODE_URL } from '@/constants/urls/main'
+import { LOCALE_FR_KEY } from '@/i18nConfig'
+import { getServerTranslation } from '@/helpers/getServerTranslation'
 import { TooManyRequestsError } from '@/helpers/server/error'
 import { fetchServer } from '@/helpers/server/fetchServer'
 import type { AuthenticationMode } from '@/types/authentication'
@@ -32,8 +35,12 @@ export const createVerificationCode = async ({
     )
     return success(data)
   } catch (error) {
+    const { t } = await getServerTranslation({
+      locale: locale ?? LOCALE_FR_KEY,
+    })
+    const translate = t as Translate
     if (error instanceof TooManyRequestsError)
-      return failure(rateLimitedError())
-    return failure(unknownCodeError())
+      return failure(rateLimitedError(translate))
+    return failure(unknownCodeError(translate))
   }
 }

--- a/apps/site/src/services/auth/create-verification-code.ts
+++ b/apps/site/src/services/auth/create-verification-code.ts
@@ -1,8 +1,8 @@
 'use server'
 
 import {
-  RateLimitedError,
-  UnknownCodeError,
+  rateLimitedError,
+  unknownCodeError,
   type EmailError,
 } from '@/components/authentication/errors'
 import { VERIFICATION_CODE_URL } from '@/constants/urls/main'
@@ -33,7 +33,7 @@ export const createVerificationCode = async ({
     return success(data)
   } catch (error) {
     if (error instanceof TooManyRequestsError)
-      return failure(new RateLimitedError())
-    return failure(new UnknownCodeError())
+      return failure(rateLimitedError())
+    return failure(unknownCodeError())
   }
 }

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -33,12 +33,22 @@ export const login = async ({
 }): Promise<Result<{ userId: string; id: string }, CodeError>> => {
   try {
     const session = await getUserSession()
+    // Reusing the current session's userId for a *different* account is what
+    // ends up attaching one id to several verified accounts (the server only
+    // rejects it on signin, after the damage is done on signup). Starting a
+    // fresh identity here keeps the 1 session id = 1 account invariant.
+    const isSwitchingAccount =
+      session?.isAuth === true && session.email !== email
     const params = locale ? `?locale=${locale}` : ''
     const data = await fetchServer<{ id: string }>(
       `${AUTHENTICATION_URL}/login${params}`,
       {
         method: 'POST',
-        body: { email, code, userId: session?.id ?? v4() },
+        body: {
+          email,
+          code,
+          userId: isSwitchingAccount ? v4() : (session?.id ?? v4()),
+        },
       }
     )
 

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -7,8 +7,11 @@ import {
   rateLimitedError,
   unknownCodeError,
   type CodeError,
+  type Translate,
 } from '@/components/authentication/errors'
 import { AUTHENTICATION_URL } from '@/constants/urls/main'
+import { LOCALE_FR_KEY } from '@/i18nConfig'
+import { getServerTranslation } from '@/helpers/getServerTranslation'
 import {
   ForbiddenError,
   TooManyRequestsError,
@@ -61,13 +64,18 @@ export const login = async ({
 
     return success({ ...data, userId: data.id })
   } catch (error) {
+    const { t } = await getServerTranslation({
+      locale: locale ?? LOCALE_FR_KEY,
+    })
+    const translate = t as Translate
     if (error instanceof UnauthorizedError) {
-      if (error.rejection === 'expired') return failure(expiredCodeError())
-      return failure(invalidCodeError())
+      if (error.rejection === 'expired') return failure(expiredCodeError(translate))
+      return failure(invalidCodeError(translate))
     }
-    if (error instanceof ForbiddenError) return failure(accountConflictError())
+    if (error instanceof ForbiddenError)
+      return failure(accountConflictError(translate))
     if (error instanceof TooManyRequestsError)
-      return failure(rateLimitedError())
-    return failure(unknownCodeError())
+      return failure(rateLimitedError(translate))
+    return failure(unknownCodeError(translate))
   }
 }

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import {
+  accountConflictError,
   expiredCodeError,
   invalidCodeError,
   rateLimitedError,
@@ -54,7 +55,7 @@ export const login = async ({
       if (error.rejection === 'expired') return failure(expiredCodeError())
       return failure(invalidCodeError())
     }
-    if (error instanceof ForbiddenError) return failure(invalidCodeError())
+    if (error instanceof ForbiddenError) return failure(accountConflictError())
     if (error instanceof TooManyRequestsError)
       return failure(rateLimitedError())
     return failure(unknownCodeError())

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -1,9 +1,9 @@
 'use server'
 
 import {
-  InvalidCodeError,
-  RateLimitedError,
-  UnknownCodeError,
+  invalidCodeError,
+  rateLimitedError,
+  unknownCodeError,
   type CodeError,
 } from '@/components/authentication/errors'
 import { AUTHENTICATION_URL } from '@/constants/urls/main'
@@ -49,11 +49,10 @@ export const login = async ({
 
     return success({ ...data, userId: data.id })
   } catch (error) {
-    if (error instanceof UnauthorizedError)
-      return failure(new InvalidCodeError())
-    if (error instanceof ForbiddenError) return failure(new InvalidCodeError())
+    if (error instanceof UnauthorizedError) return failure(invalidCodeError())
+    if (error instanceof ForbiddenError) return failure(invalidCodeError())
     if (error instanceof TooManyRequestsError)
-      return failure(new RateLimitedError())
-    return failure(new UnknownCodeError())
+      return failure(rateLimitedError())
+    return failure(unknownCodeError())
   }
 }

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import {
+  expiredCodeError,
   invalidCodeError,
   rateLimitedError,
   unknownCodeError,
@@ -49,7 +50,10 @@ export const login = async ({
 
     return success({ ...data, userId: data.id })
   } catch (error) {
-    if (error instanceof UnauthorizedError) return failure(invalidCodeError())
+    if (error instanceof UnauthorizedError) {
+      if (error.rejection === 'expired') return failure(expiredCodeError())
+      return failure(invalidCodeError())
+    }
     if (error instanceof ForbiddenError) return failure(invalidCodeError())
     if (error instanceof TooManyRequestsError)
       return failure(rateLimitedError())

--- a/packages/core/src/lib/result.ts
+++ b/packages/core/src/lib/result.ts
@@ -1,15 +1,23 @@
 import type { ErrorWithCode } from './errors.ts'
 
+/**
+ * A minimal serializable error contract. `ErrorWithCode` instances satisfy it,
+ * and so do plain `{ code, message }` objects — which is what server actions
+ * must return: React Flight cannot serialize `Error` instances across the
+ * server/client boundary.
+ */
+export type ErrorPayload = { code: string; message: string }
+
 export type Success<Data> = Data extends void
   ? { success: true }
   : { success: true; data: Data }
 
-type Failure<Err extends ErrorWithCode = ErrorWithCode> = {
+type Failure<Err extends ErrorPayload = ErrorWithCode> = {
   success: false
   error: Err
 }
 
-export type Result<Data, Err extends ErrorWithCode = ErrorWithCode> =
+export type Result<Data, Err extends ErrorPayload = ErrorWithCode> =
   | Success<Data>
   | Failure<Err>
 
@@ -22,6 +30,6 @@ export function success<Data>(data?: Data) {
   return { success: true, data }
 }
 
-export function failure<Err extends ErrorWithCode>(error: Err): Failure<Err> {
+export function failure<Err extends ErrorPayload>(error: Err): Failure<Err> {
   return { success: false, error }
 }


### PR DESCRIPTION
## Contexte

En tentant de se connecter avec un code de vérification reçu par e-mail, un utilisateur recevait des erreurs trompeuses (« code invalide ») alors que le code était valide. L'investigation a révélé **trois problèmes superposés**, dont un problème structurel de données.

## Origine du problème

### 1. Erreur de sérialisation React Flight
Les server actions retournaient des instances `Error` dans `failure(...)`. React Flight ne peut pas sérialiser une `Error` à destination des Client Components :

```
Only plain objects can be passed to Client Components from Server Components. Error objects are not supported.
```

Le code discriminatoire de l'erreur (ex. `invalid_code`) était donc perdu à l'arrivée sur le client, qui ne pouvait pas réagir correctement.

### 2. Une erreur « code expiré » affichée comme « code invalide »
Le serveur savait déjà *pourquoi* un code était rejeté (`expired` vs `mismatch` vs `never_requested`), mais ne remontait pas cette raison : tout rejet était un simple 401 traduit côté client en « code invalide ». Or un code n'est valide qu'**1 heure** : un utilisateur saisissant un code reçu mais expiré se voyait dire qu'il s'était trompé, au lieu d'être invité à demander un nouveau code.

### 3. Plusieurs comptes attachés au même id de session (cause racine)
- `VerifiedUser.id` **n'est pas unique** dans le schéma Prisma (seul `email` est clé primaire).
- Le chemin d'**inscription** créait le compte avec `id = loginDto.userId` **sans aucun contrôle** que ce userId soit déjà rattaché à un autre compte. La garde n'existait que sur le chemin signin, donc *après* le mal fait.
- Le client envoie `session?.id ?? v4()` à chaque login : toute inscription réalisée en conservant une session réutilisait le même id, créant silencieusement plusieurs comptes partageant un même id.
- Conséquence : se connecter à l'un de ces comptes depuis une session dont l'id était déjà « pris » → 403 masqué en « code invalide ».

## Solutions adoptées

| Commit | Contenu |
| --- | --- |
| 🐛 **Fix serialization error when entering verification code** | `packages/core` : `Result/failure` accepte désormais des payloads plats `{ code, message }` ; les erreurs d'auth deviennent des unions discriminées d'objets plats avec factories ; les server actions et `useAuthEffects` utilisent les factories. Test de régression ajouté. |
| ✨ **Tell the user apart an expired verification code from an invalid one** | Le 401 renvoie `{ rejection }` ; `UnauthorizedError` porte la raison (`handleApiResponse`) ; le formulaire affiche un message dédié « code expiré, demandez-en un nouveau ». |
| ✨ **Tell the user when the session blocks a login (account conflict)** | Le 403 « session déjà associée à un autre compte » est mappé vers un code d'erreur dédié avec un message actionnable : *« Cette session est déjà associée à un autre compte. Déconnectez-vous puis réessayez. »* |
| 🔒 **Enforce the "one session userId = one account" invariant** | Serveur : la garde de conflit est remontée pour couvrir aussi l'inscription (403, aucun compte créé). Site : un `v4()` frais est envoyé lors d'un changement de compte au lieu de réutiliser l'id de session. Test de régression ajouté. |
| 🗄️ **Add data migration to give every VerifiedUser a unique session id (NGC-3402)** | Script `apps/server/scripts/NGC-3402-20260804.ts` : réassigne un uuid unique à chaque compte partageant un id (le compte correspondant à la ligne `User` garde l'id), crée les lignes `User` et re-pointe les simulations pour préserver les FK. Dry-run par défaut, idempotent. |

## Vérifications
- Serveur : typecheck + eslint OK, **780 tests passent** (779 existants + 1 nouveau).
- Site : typecheck + eslint OK, **193 tests passent**.
- Migration validée sur la base de dev locale : 1 groupe d'ids dupliqués corrigé, 0 restant, second run = no-op.

## ⚠️ Points d'attention pour la mise en prod
1. **Déployer d'abord le correctif, puis lancer la migration** `NGC-3402-20260804.ts` (`--no-dry`) sur la base de production : si la migration tourne avant le correctif, l'ancien client/serveur recrée immédiatement des doublons.
2. Les `RefreshToken` existants d'un id partagé ne sont pas réattribuables (pas d'e-mail dans la table) : ils restent au « propriétaire » de l'id. Résiduel, sans aggravation (TTL 6 mois).
