### PR TITLE
🔒 Enforce one session id = one account (server guard) [NGC-3770]

### DIFF
--- a/apps/server/src/features/authentication/__tests__/fixtures/login.fixture.ts
+++ b/apps/server/src/features/authentication/__tests__/fixtures/login.fixture.ts
@@ -6,6 +6,7 @@ import {
   brevoSendEmail,
   brevoUpdateContact,
 } from '../../../../adapters/brevo/__tests__/fixtures/server.fixture.ts'
+import { authHeaders } from '../../../../core/__tests__/fixtures/authentication.fixture.ts'
 import {
   mswServer,
   resetMswServer,
@@ -36,8 +37,10 @@ export const login = async ({
   const response = await agent
     .post(LOGIN_ROUTE)
     // The session's userId used to be sent in the body; it now travels as
-    // the `x-user-id` header, exactly like the site proxy forwards it.
-    .set('x-user-id', userId)
+    // the `x-user-id` header, exactly like the site proxy forwards it. The
+    // shared `x-internal-key` proves the request comes from the site, not
+    // from a browser.
+    .set(authHeaders({ userId }))
     .send({
       email,
       code,

--- a/apps/server/src/features/authentication/__tests__/fixtures/login.fixture.ts
+++ b/apps/server/src/features/authentication/__tests__/fixtures/login.fixture.ts
@@ -35,8 +35,10 @@ export const login = async ({
 
   const response = await agent
     .post(LOGIN_ROUTE)
+    // The session's userId used to be sent in the body; it now travels as
+    // the `x-user-id` header, exactly like the site proxy forwards it.
+    .set('x-user-id', userId)
     .send({
-      userId,
       email,
       code,
     })

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -602,6 +602,30 @@ describe('Given a NGC user', () => {
             })
           )
         })
+
+        test(`Then signing up a new email with the same userId returns a ${StatusCodes.FORBIDDEN} error and does not create an account`, async () => {
+          const emailC = faker.internet.email().toLocaleLowerCase()
+          const signUpCodeC = await createVerificationCode({
+            agent,
+            verificationCode: { email: emailC },
+            mode: VerificationCodeMode.signUp,
+          })
+
+          await agent
+            .post(url)
+            .send({
+              userId: userIdA,
+              email: signUpCodeC.email,
+              code: signUpCodeC.code,
+            })
+            .expect(StatusCodes.FORBIDDEN)
+
+          const createdUser = await prisma.verifiedUser.findUnique({
+            where: { email: emailC },
+          })
+
+          expect(createdUser).toBeNull()
+        })
       })
     })
 

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -13,6 +13,7 @@ import {
 import { VerificationCodeMode } from '../../../adapters/prisma/generated.ts'
 import * as prismaTransactionAdapter from '../../../adapters/prisma/transaction.ts'
 import app from '../../../app.ts'
+import { config } from '../../../config.ts'
 import { mswServer } from '../../../core/__tests__/fixtures/server.fixture.ts'
 import { EventBus } from '../../../core/event-bus/event-bus.ts'
 import { Locales } from '../../../core/i18n/constant.ts'
@@ -29,6 +30,13 @@ vi.mock('@sentry/node', async () => ({
   captureException: vi.fn(),
 }))
 
+// Every login request carries the shared `x-internal-key`, exactly like the
+// site's `fetchServer` sends it: it is what makes the `x-user-id` header
+// trustworthy.
+const loginHeaders = {
+  'x-internal-key': config.security.internalApiKey,
+}
+
 describe('Given a NGC user', () => {
   const agent = supertest(app)
   const url = LOGIN_ROUTE
@@ -44,7 +52,20 @@ describe('Given a NGC user', () => {
   describe('When logging in', () => {
     describe('And no data provided', () => {
       test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
-        await agent.post(url).expect(StatusCodes.BAD_REQUEST)
+        await agent.post(url).set(loginHeaders).expect(StatusCodes.BAD_REQUEST)
+      })
+    })
+
+    describe('And no internal key header', () => {
+      test(`Then it returns a ${StatusCodes.UNAUTHORIZED} error`, async () => {
+        await agent
+          .post(url)
+          .set('x-user-id', faker.string.uuid())
+          .send({
+            email: faker.internet.email(),
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+          })
+          .expect(StatusCodes.UNAUTHORIZED)
       })
     })
 
@@ -52,6 +73,7 @@ describe('Given a NGC user', () => {
       test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
         await agent
           .post(url)
+          .set(loginHeaders)
           .set('x-user-id', faker.string.alpha(34))
           .send({
             email: faker.internet.email(),
@@ -65,6 +87,7 @@ describe('Given a NGC user', () => {
       test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
         await agent
           .post(url)
+          .set(loginHeaders)
           .send({
             email: 'Je ne donne jamais mon email',
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -77,6 +100,7 @@ describe('Given a NGC user', () => {
       test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
         await agent
           .post(url)
+          .set(loginHeaders)
           .send({
             email: faker.internet.email(),
             code: '42',
@@ -89,6 +113,7 @@ describe('Given a NGC user', () => {
       test(`Then it returns a ${StatusCodes.UNAUTHORIZED} error`, async () => {
         await agent
           .post(url)
+          .set(loginHeaders)
           .send({
             email: faker.internet.email(),
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -102,6 +127,7 @@ describe('Given a NGC user', () => {
 
         await agent
           .post(url)
+          .set(loginHeaders)
           .set('x-user-id', userId)
           .send({
             email,
@@ -124,6 +150,7 @@ describe('Given a NGC user', () => {
 
         await agent
           .post(url)
+          .set(loginHeaders)
           .set('x-user-id', userId)
           .send({
             email,
@@ -150,6 +177,7 @@ describe('Given a NGC user', () => {
 
         await agent
           .post(url)
+          .set(loginHeaders)
           .send({
             email: verificationCode.email,
             code: '654321',
@@ -181,6 +209,7 @@ describe('Given a NGC user', () => {
 
         const response = await agent
           .post(url)
+          .set(loginHeaders)
           .set('x-user-id', sessionUserId)
           .send(payload)
           .expect(StatusCodes.OK)
@@ -223,6 +252,7 @@ describe('Given a NGC user', () => {
 
         await agent
           .post(url)
+          .set(loginHeaders)
           .set('x-user-id', sessionUserId)
           .send(payload)
           .expect(StatusCodes.OK)
@@ -241,6 +271,7 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set(loginHeaders)
             .send({
               email: verificationCode.email,
               code: verificationCode.code,
@@ -261,7 +292,11 @@ describe('Given a NGC user', () => {
             brevoSendEmail({ networkError: true })
           )
 
-          await agent.post(url).send({ email, code }).expect(StatusCodes.OK)
+          await agent
+            .post(url)
+            .set(loginHeaders)
+            .send({ email, code })
+            .expect(StatusCodes.OK)
 
           const createdUser = await prisma.verifiedUser.findUnique({
             where: { email },
@@ -282,6 +317,7 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set(loginHeaders)
             .send({
               email: verificationCode.email,
               code: verificationCode.code,
@@ -296,7 +332,7 @@ describe('Given a NGC user', () => {
             expirationDate,
           })
 
-          await agent.post(url).send({
+          await agent.post(url).set(loginHeaders).send({
             email: verificationCode.email,
             code: verificationCode.code,
           })
@@ -329,6 +365,7 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set(loginHeaders)
             .set('x-user-id', sessionUserId)
             .send(payload)
             .expect(StatusCodes.OK)
@@ -363,7 +400,11 @@ describe('Given a NGC user', () => {
 
           mswServer.use(brevoUpdateContact(), brevoSendEmail())
 
-          await agent.post(url).send(payload).expect(StatusCodes.OK)
+          await agent
+            .post(url)
+            .set(loginHeaders)
+            .send(payload)
+            .expect(StatusCodes.OK)
 
           const [verificationCode] = await prisma.verificationCode.findMany({
             where: { email },
@@ -417,6 +458,7 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set(loginHeaders)
             .set('x-user-id', sessionUserId)
             .send(payload)
             .expect(StatusCodes.OK)
@@ -464,6 +506,7 @@ describe('Given a NGC user', () => {
 
             await agent
               .post(url)
+              .set(loginHeaders)
               .set('origin', 'https://evil.example.com')
               .set('x-user-id', sessionUserId)
               .send(payload)
@@ -512,6 +555,7 @@ describe('Given a NGC user', () => {
 
             await agent
               .post(url)
+              .set(loginHeaders)
               .set('x-user-id', sessionUserId)
               .send(payload)
               .query({ locale: Locales.en })
@@ -541,6 +585,7 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set(loginHeaders)
             .set('x-user-id', userIdA)
             .send({
               email: signUpCodeA.email,
@@ -562,6 +607,7 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set(loginHeaders)
             .set('x-user-id', userIdB)
             .send({
               email: signUpCodeB.email,
@@ -581,6 +627,7 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set(loginHeaders)
             .set('x-user-id', userIdA)
             .send({
               email: signInCode.email,
@@ -596,10 +643,14 @@ describe('Given a NGC user', () => {
             mode: VerificationCodeMode.signIn,
           })
 
-          await agent.post(url).set('x-user-id', userIdA).send({
-            email: signInCode.email,
-            code: signInCode.code,
-          })
+          await agent
+            .post(url)
+            .set(loginHeaders)
+            .set('x-user-id', userIdA)
+            .send({
+              email: signInCode.email,
+              code: signInCode.code,
+            })
 
           expect(logger.warn).toHaveBeenCalledWith(
             'Login rejected: userId attached to another account',
@@ -622,6 +673,7 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set(loginHeaders)
             .set('x-user-id', userIdA)
             .send({
               email: signUpCodeC.email,
@@ -659,6 +711,7 @@ describe('Given a NGC user', () => {
       test(`Then it returns a ${StatusCodes.INTERNAL_SERVER_ERROR} error`, async () => {
         await agent
           .post(url)
+          .set(loginHeaders)
           .send({
             email: faker.internet.email(),
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
@@ -672,6 +725,7 @@ describe('Given a NGC user', () => {
 
         await agent
           .post(url)
+          .set(loginHeaders)
           .set('x-user-id', userId)
           .send({
             email,
@@ -695,6 +749,7 @@ describe('Given a NGC user', () => {
 
         await agent
           .post(url)
+          .set(loginHeaders)
           .set('x-user-id', userId)
           .send({
             email,

--- a/apps/server/src/features/authentication/__tests__/login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/login.spec.ts
@@ -48,12 +48,12 @@ describe('Given a NGC user', () => {
       })
     })
 
-    describe('And invalid userId', () => {
+    describe('And an invalid session userId header', () => {
       test(`Then it returns a ${StatusCodes.BAD_REQUEST} error`, async () => {
         await agent
           .post(url)
+          .set('x-user-id', faker.string.alpha(34))
           .send({
-            userId: faker.string.alpha(34),
             email: faker.internet.email(),
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
           })
@@ -66,7 +66,6 @@ describe('Given a NGC user', () => {
         await agent
           .post(url)
           .send({
-            userId: faker.string.uuid(),
             email: 'Je ne donne jamais mon email',
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
           })
@@ -79,7 +78,6 @@ describe('Given a NGC user', () => {
         await agent
           .post(url)
           .send({
-            userId: faker.string.uuid(),
             email: faker.internet.email(),
             code: '42',
           })
@@ -92,7 +90,6 @@ describe('Given a NGC user', () => {
         await agent
           .post(url)
           .send({
-            userId: faker.string.uuid(),
             email: faker.internet.email(),
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
           })
@@ -103,11 +100,13 @@ describe('Given a NGC user', () => {
         const userId = faker.string.uuid()
         const email = faker.internet.email().toLocaleLowerCase()
 
-        await agent.post(url).send({
-          userId,
-          email,
-          code: faker.number.int({ min: 100000, max: 999999 }).toString(),
-        })
+        await agent
+          .post(url)
+          .set('x-user-id', userId)
+          .send({
+            email,
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+          })
 
         expect(logger.warn).toHaveBeenCalledWith(
           'Login rejected: invalid verification code',
@@ -123,11 +122,13 @@ describe('Given a NGC user', () => {
         const userId = faker.string.uuid()
         const email = faker.internet.email().toLocaleLowerCase()
 
-        await agent.post(url).send({
-          userId,
-          email,
-          code: faker.number.int({ min: 100000, max: 999999 }).toString(),
-        })
+        await agent
+          .post(url)
+          .set('x-user-id', userId)
+          .send({
+            email,
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+          })
 
         expect(captureException).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -150,7 +151,6 @@ describe('Given a NGC user', () => {
         await agent
           .post(url)
           .send({
-            userId: faker.string.uuid(),
             email: verificationCode.email,
             code: '654321',
           })
@@ -171,8 +171,8 @@ describe('Given a NGC user', () => {
       test(`Then it returns a ${StatusCodes.OK} response with a cookie`, async () => {
         const verificationCode = await createVerificationCode({ agent })
 
+        const sessionUserId = faker.string.uuid()
         const payload = {
-          userId: faker.string.uuid(),
           email: verificationCode.email,
           code: verificationCode.code,
         }
@@ -181,6 +181,7 @@ describe('Given a NGC user', () => {
 
         const response = await agent
           .post(url)
+          .set('x-user-id', sessionUserId)
           .send(payload)
           .expect(StatusCodes.OK)
 
@@ -192,7 +193,7 @@ describe('Given a NGC user', () => {
         await EventBus.flush()
 
         expect(jwt.decode(token!)).toEqual({
-          userId: payload.userId,
+          userId: sessionUserId,
           email: verificationCode.email,
           exp: expect.any(Number),
           iat: expect.any(Number),
@@ -202,8 +203,8 @@ describe('Given a NGC user', () => {
       test('Then it updates brevo contact', async () => {
         const verificationCode = await createVerificationCode({ agent })
 
+        const sessionUserId = faker.string.uuid()
         const payload = {
-          userId: faker.string.uuid(),
           email: verificationCode.email,
           code: verificationCode.code,
         }
@@ -212,7 +213,7 @@ describe('Given a NGC user', () => {
             expectBody: {
               email: verificationCode.email,
               attributes: {
-                USER_ID: payload.userId,
+                USER_ID: sessionUserId,
               },
               updateEnabled: true,
             },
@@ -220,7 +221,11 @@ describe('Given a NGC user', () => {
           brevoSendEmail()
         )
 
-        await agent.post(url).send(payload).expect(StatusCodes.OK)
+        await agent
+          .post(url)
+          .set('x-user-id', sessionUserId)
+          .send(payload)
+          .expect(StatusCodes.OK)
 
         await EventBus.flush()
       })
@@ -237,7 +242,6 @@ describe('Given a NGC user', () => {
           await agent
             .post(url)
             .send({
-              userId: faker.string.uuid(),
               email: verificationCode.email,
               code: verificationCode.code,
             })
@@ -257,10 +261,7 @@ describe('Given a NGC user', () => {
             brevoSendEmail({ networkError: true })
           )
 
-          await agent
-            .post(url)
-            .send({ userId: faker.string.uuid(), email, code })
-            .expect(StatusCodes.OK)
+          await agent.post(url).send({ email, code }).expect(StatusCodes.OK)
 
           const createdUser = await prisma.verifiedUser.findUnique({
             where: { email },
@@ -284,7 +285,6 @@ describe('Given a NGC user', () => {
             .send({
               email: verificationCode.email,
               code: verificationCode.code,
-              userId: faker.string.uuid(),
             })
             .expect(StatusCodes.UNAUTHORIZED)
         })
@@ -299,7 +299,6 @@ describe('Given a NGC user', () => {
           await agent.post(url).send({
             email: verificationCode.email,
             code: verificationCode.code,
-            userId: faker.string.uuid(),
           })
 
           expect(logger.warn).toHaveBeenCalledWith(
@@ -320,15 +319,19 @@ describe('Given a NGC user', () => {
             mode: VerificationCodeMode.signUp,
           })
 
+          const sessionUserId = faker.string.uuid()
           const payload = {
-            userId: faker.string.uuid(),
             email,
             code,
           }
 
           mswServer.use(brevoUpdateContact(), brevoSendEmail())
 
-          await agent.post(url).send(payload).expect(StatusCodes.OK)
+          await agent
+            .post(url)
+            .set('x-user-id', sessionUserId)
+            .send(payload)
+            .expect(StatusCodes.OK)
 
           const createdUser = await prisma.verifiedUser.findUnique({
             where: { email },
@@ -336,7 +339,7 @@ describe('Given a NGC user', () => {
 
           expect(createdUser).toEqual({
             email,
-            id: payload.userId,
+            id: sessionUserId,
             name: null,
             optedInForCommunications: false,
             position: null,
@@ -354,7 +357,6 @@ describe('Given a NGC user', () => {
           })
 
           const payload = {
-            userId: faker.string.uuid(),
             email,
             code,
           }
@@ -381,10 +383,10 @@ describe('Given a NGC user', () => {
             mode: VerificationCodeMode.signUp,
           })
 
+          const sessionUserId = faker.string.uuid()
           const payload = {
             email,
             code,
-            userId: faker.string.uuid(),
           }
 
           mswServer.use(
@@ -392,7 +394,7 @@ describe('Given a NGC user', () => {
               expectBody: {
                 email,
                 attributes: {
-                  USER_ID: payload.userId,
+                  USER_ID: sessionUserId,
                 },
                 updateEnabled: true,
               },
@@ -413,7 +415,11 @@ describe('Given a NGC user', () => {
             })
           )
 
-          await agent.post(url).send(payload).expect(StatusCodes.OK)
+          await agent
+            .post(url)
+            .set('x-user-id', sessionUserId)
+            .send(payload)
+            .expect(StatusCodes.OK)
           await EventBus.flush()
         })
 
@@ -424,8 +430,8 @@ describe('Given a NGC user', () => {
               mode: VerificationCodeMode.signUp,
             })
 
+            const sessionUserId = faker.string.uuid()
             const payload = {
-              userId: faker.string.uuid(),
               email,
               code,
             }
@@ -435,7 +441,7 @@ describe('Given a NGC user', () => {
                 expectBody: {
                   email,
                   attributes: {
-                    USER_ID: payload.userId,
+                    USER_ID: sessionUserId,
                   },
                   updateEnabled: true,
                 },
@@ -459,6 +465,7 @@ describe('Given a NGC user', () => {
             await agent
               .post(url)
               .set('origin', 'https://evil.example.com')
+              .set('x-user-id', sessionUserId)
               .send(payload)
               .expect(StatusCodes.OK)
           })
@@ -471,8 +478,8 @@ describe('Given a NGC user', () => {
               mode: VerificationCodeMode.signUp,
             })
 
+            const sessionUserId = faker.string.uuid()
             const payload = {
-              userId: faker.string.uuid(),
               email,
               code,
             }
@@ -482,7 +489,7 @@ describe('Given a NGC user', () => {
                 expectBody: {
                   email,
                   attributes: {
-                    USER_ID: payload.userId,
+                    USER_ID: sessionUserId,
                   },
                   updateEnabled: true,
                 },
@@ -505,6 +512,7 @@ describe('Given a NGC user', () => {
 
             await agent
               .post(url)
+              .set('x-user-id', sessionUserId)
               .send(payload)
               .query({ locale: Locales.en })
               .expect(StatusCodes.OK)
@@ -512,7 +520,7 @@ describe('Given a NGC user', () => {
         })
       })
 
-      describe('And userId is already attached to another verified account', () => {
+      describe('And the session userId is already attached to another verified account', () => {
         let emailA: string
         let emailB: string
         let userIdA: string
@@ -533,8 +541,8 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set('x-user-id', userIdA)
             .send({
-              userId: userIdA,
               email: signUpCodeA.email,
               code: signUpCodeA.code,
             })
@@ -554,8 +562,8 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set('x-user-id', userIdB)
             .send({
-              userId: userIdB,
               email: signUpCodeB.email,
               code: signUpCodeB.code,
             })
@@ -564,7 +572,7 @@ describe('Given a NGC user', () => {
           await EventBus.flush()
         })
 
-        test(`Then it returns a ${StatusCodes.FORBIDDEN} error`, async () => {
+        test(`Then signing in with that session returns a ${StatusCodes.FORBIDDEN} error`, async () => {
           const signInCode = await createVerificationCode({
             agent,
             verificationCode: { email: emailB },
@@ -573,8 +581,8 @@ describe('Given a NGC user', () => {
 
           await agent
             .post(url)
+            .set('x-user-id', userIdA)
             .send({
-              userId: userIdA,
               email: signInCode.email,
               code: signInCode.code,
             })
@@ -588,8 +596,7 @@ describe('Given a NGC user', () => {
             mode: VerificationCodeMode.signIn,
           })
 
-          await agent.post(url).send({
-            userId: userIdA,
+          await agent.post(url).set('x-user-id', userIdA).send({
             email: signInCode.email,
             code: signInCode.code,
           })
@@ -603,7 +610,7 @@ describe('Given a NGC user', () => {
           )
         })
 
-        test(`Then signing up a new email with the same userId returns a ${StatusCodes.FORBIDDEN} error and does not create an account`, async () => {
+        test(`Then signing up a new email with that session creates the account with a fresh userId instead of reusing the taken one`, async () => {
           const emailC = faker.internet.email().toLocaleLowerCase()
           const signUpCodeC = await createVerificationCode({
             agent,
@@ -611,20 +618,27 @@ describe('Given a NGC user', () => {
             mode: VerificationCodeMode.signUp,
           })
 
+          mswServer.use(brevoUpdateContact(), brevoSendEmail())
+
           await agent
             .post(url)
+            .set('x-user-id', userIdA)
             .send({
-              userId: userIdA,
               email: signUpCodeC.email,
               code: signUpCodeC.code,
             })
-            .expect(StatusCodes.FORBIDDEN)
+            .expect(StatusCodes.OK)
+
+          await EventBus.flush()
 
           const createdUser = await prisma.verifiedUser.findUnique({
             where: { email: emailC },
           })
 
-          expect(createdUser).toBeNull()
+          expect(createdUser).not.toBeNull()
+          // The invariant holds: the new account must not share userIdA with
+          // account A.
+          expect(createdUser?.id).not.toBe(userIdA)
         })
       })
     })
@@ -646,7 +660,6 @@ describe('Given a NGC user', () => {
         await agent
           .post(url)
           .send({
-            userId: faker.string.uuid(),
             email: faker.internet.email(),
             code: faker.number.int({ min: 100000, max: 999999 }).toString(),
           })
@@ -657,11 +670,13 @@ describe('Given a NGC user', () => {
         const userId = faker.string.uuid()
         const email = faker.internet.email().toLocaleLowerCase()
 
-        await agent.post(url).send({
-          userId,
-          email,
-          code: faker.number.int({ min: 100000, max: 999999 }).toString(),
-        })
+        await agent
+          .post(url)
+          .set('x-user-id', userId)
+          .send({
+            email,
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+          })
 
         expect(logger.error).toHaveBeenCalledWith(
           'Login failed',
@@ -678,11 +693,13 @@ describe('Given a NGC user', () => {
         const userId = faker.string.uuid()
         const email = faker.internet.email().toLocaleLowerCase()
 
-        await agent.post(url).send({
-          userId,
-          email,
-          code: faker.number.int({ min: 100000, max: 999999 }).toString(),
-        })
+        await agent
+          .post(url)
+          .set('x-user-id', userId)
+          .send({
+            email,
+            code: faker.number.int({ min: 100000, max: 999999 }).toString(),
+          })
 
         expect(captureException).toHaveBeenCalledWith(
           databaseError,

--- a/apps/server/src/features/authentication/__tests__/reconcile-simulations-after-login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/reconcile-simulations-after-login.spec.ts
@@ -65,7 +65,7 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
       await agent
         .post(LOGIN_ROUTE)
-        .set('x-user-id', anonUserId)
+        .set(authHeaders({ userId: anonUserId }))
         .send({
           email: verificationCode.email,
           code: verificationCode.code,
@@ -108,7 +108,7 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
       await agent
         .post(LOGIN_ROUTE)
-        .set('x-user-id', verifiedUserId)
+        .set(authHeaders({ userId: verifiedUserId }))
         .send({
           email: signUpCode.email,
           code: signUpCode.code,
@@ -136,7 +136,7 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
         await agent
           .post(LOGIN_ROUTE)
-          .set('x-user-id', anonUserId)
+          .set(authHeaders({ userId: anonUserId }))
           .send({
             email: signInCode.email,
             code: signInCode.code,
@@ -189,7 +189,7 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
         await agent
           .post(LOGIN_ROUTE)
-          .set('x-user-id', verifiedUserId)
+          .set(authHeaders({ userId: verifiedUserId }))
           .send({
             email: signUpCode.email,
             code: signUpCode.code,
@@ -227,7 +227,7 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
           await agent
             .post(LOGIN_ROUTE)
-            .set('x-user-id', anonUserId)
+            .set(authHeaders({ userId: anonUserId }))
             .send({
               email: signInCode.email,
               code: signInCode.code,

--- a/apps/server/src/features/authentication/__tests__/reconcile-simulations-after-login.spec.ts
+++ b/apps/server/src/features/authentication/__tests__/reconcile-simulations-after-login.spec.ts
@@ -65,8 +65,8 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
       await agent
         .post(LOGIN_ROUTE)
+        .set('x-user-id', anonUserId)
         .send({
-          userId: anonUserId,
           email: verificationCode.email,
           code: verificationCode.code,
         })
@@ -108,8 +108,8 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
       await agent
         .post(LOGIN_ROUTE)
+        .set('x-user-id', verifiedUserId)
         .send({
-          userId: verifiedUserId,
           email: signUpCode.email,
           code: signUpCode.code,
         })
@@ -136,8 +136,8 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
         await agent
           .post(LOGIN_ROUTE)
+          .set('x-user-id', anonUserId)
           .send({
-            userId: anonUserId,
             email: signInCode.email,
             code: signInCode.code,
           })
@@ -189,8 +189,8 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
         await agent
           .post(LOGIN_ROUTE)
+          .set('x-user-id', verifiedUserId)
           .send({
-            userId: verifiedUserId,
             email: signUpCode.email,
             code: signUpCode.code,
           })
@@ -227,8 +227,8 @@ describe('Given a NGC user with a previous anonymous session', () => {
 
           await agent
             .post(LOGIN_ROUTE)
+            .set('x-user-id', anonUserId)
             .send({
-              userId: anonUserId,
               email: signInCode.email,
               code: signInCode.code,
             })

--- a/apps/server/src/features/authentication/authentication.controller.ts
+++ b/apps/server/src/features/authentication/authentication.controller.ts
@@ -53,10 +53,19 @@ router
     async (req, res) => {
       const startedAt = Date.now()
 
-      // The current session's userId is forwarded by the proxy as the
-      // `x-user-id` header. The server trusts it - not a client-provided
-      // body field - to enforce the "one session userId = one account"
-      // invariant.
+      // The login endpoint is only reachable through the site's server-side
+      // `fetchServer`, which always forwards the shared `x-internal-key`
+      // alongside the session identity. Requiring it makes the `x-user-id`
+      // header trustworthy - it is set from the signed session cookie by the
+      // site proxy, not by the browser - so the "one session userId = one
+      // account" invariant can rely on it instead of a client-settable field.
+      if (req.headers['x-internal-key'] !== config.security.internalApiKey) {
+        return res.status(StatusCodes.UNAUTHORIZED).end()
+      }
+
+      // The current session's userId travels as the `x-user-id` header. The
+      // server uses it - not a client-provided body field - to enforce the
+      // "one session userId = one account" invariant.
       const rawSessionUserId = req.headers['x-user-id']
       let sessionUserId: string | undefined
       if (typeof rawSessionUserId === 'string') {

--- a/apps/server/src/features/authentication/authentication.controller.ts
+++ b/apps/server/src/features/authentication/authentication.controller.ts
@@ -1,6 +1,7 @@
 import { captureException } from '@sentry/node'
 import express from 'express'
 import { StatusCodes } from 'http-status-codes'
+import * as v from 'valibot'
 import { config } from '../../config.ts'
 import { EntityNotFoundException } from '../../core/errors/EntityNotFoundException.ts'
 import { ForbiddenException } from '../../core/errors/ForbiddenException.ts'
@@ -51,8 +52,26 @@ router
     validateRequest(LoginValidator),
     async (req, res) => {
       const startedAt = Date.now()
+
+      // The current session's userId is forwarded by the proxy as the
+      // `x-user-id` header. The server trusts it - not a client-provided
+      // body field - to enforce the "one session userId = one account"
+      // invariant.
+      const rawSessionUserId = req.headers['x-user-id']
+      let sessionUserId: string | undefined
+      if (typeof rawSessionUserId === 'string') {
+        const parsedSessionUserId = v.safeParse(
+          v.pipe(v.string(), v.uuid()),
+          rawSessionUserId
+        )
+        if (!parsedSessionUserId.success) {
+          return res.status(StatusCodes.BAD_REQUEST).end()
+        }
+        sessionUserId = parsedSessionUserId.output
+      }
+
       const context = {
-        userId: req.body.userId,
+        userId: sessionUserId,
         email: maskEmail(req.body.email),
         locale: req.query.locale,
       }
@@ -65,6 +84,7 @@ router
         const { token, user, mode } = await login({
           loginDto: req.body,
           locale: req.query.locale,
+          sessionUserId,
         })
 
         res.cookie(COOKIE_NAME, token, getCookieOptions(config.app.origin))

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -175,25 +175,28 @@ export async function createAccountOrSignin(loginDto: LoginDto) {
       { session }
     )
 
-    if (existingUser) {
-      // Reject login if the anonymous session userId is already attached
-      // to a different verified account
-      if (existingUser.id !== loginDto.userId) {
-        const conflictingUser = await session.verifiedUser.findFirst({
-          where: {
-            id: loginDto.userId,
-            NOT: { email: loginDto.email },
-          },
-          select: { email: true },
-        })
+    // A session userId must map to at most one verified account. Reusing a
+    // userId already attached to a different verified account would silently
+    // create duplicate accounts sharing the same id on signup (the `id`
+    // column of VerifiedUser is not unique), and is already rejected on
+    // signin. Enforce the invariant on both paths.
+    if (existingUser?.id !== loginDto.userId) {
+      const conflictingUser = await session.verifiedUser.findFirst({
+        where: {
+          id: loginDto.userId,
+          NOT: { email: loginDto.email },
+        },
+        select: { email: true },
+      })
 
-        if (conflictingUser) {
-          throw new ForbiddenException(
-            'userId is already attached to another verified account'
-          )
-        }
+      if (conflictingUser) {
+        throw new ForbiddenException(
+          'userId is already attached to another verified account'
+        )
       }
+    }
 
+    if (existingUser) {
       return [existingUser, VerificationCodeMode.signIn] as const
     }
 

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@nosgestesclimat/core/prisma/client'
 import { isPrismaErrorNotFound } from '@nosgestesclimat/core/prisma/utils'
+import { randomUUID } from 'crypto'
 import type { CookieOptions } from 'express'
 import jwt from 'jsonwebtoken'
 import {
@@ -132,15 +133,26 @@ export const verifyCode = async (
 export const login = async ({
   loginDto,
   locale,
+  sessionUserId,
 }: {
   loginDto: LoginDto
   locale: Locales
+  /**
+   * The current session's userId, forwarded by the proxy as the `x-user-id`
+   * header. The server relies on it to enforce the
+   * "one session userId = one account" invariant instead of trusting a
+   * client-provided id.
+   */
+  sessionUserId?: string
 }) => {
-  const { user, mode, token } = await createAccountOrSignin(loginDto)
+  const { user, mode, token } = await createAccountOrSignin({
+    loginDto,
+    sessionUserId,
+  })
 
   const loginEvent = new LoginEvent({
     user,
-    previousUserId: loginDto.userId,
+    previousUserId: sessionUserId,
     mode,
     locale,
   })
@@ -162,7 +174,13 @@ export function createToken(user: Pick<VerifiedUser, 'id' | 'email'>) {
   )
 }
 
-export async function createAccountOrSignin(loginDto: LoginDto) {
+export async function createAccountOrSignin({
+  loginDto,
+  sessionUserId,
+}: {
+  loginDto: LoginDto
+  sessionUserId?: string
+}) {
   const verificationCode = await verifyCode(loginDto)
 
   const [user, mode] = await transaction(async (session) => {
@@ -175,35 +193,52 @@ export async function createAccountOrSignin(loginDto: LoginDto) {
       { session }
     )
 
-    // A session userId must map to at most one verified account. Reusing a
-    // userId already attached to a different verified account would silently
-    // create duplicate accounts sharing the same id on signup (the `id`
-    // column of VerifiedUser is not unique), and is already rejected on
-    // signin. Enforce the invariant on both paths.
-    if (existingUser?.id !== loginDto.userId) {
-      const conflictingUser = await session.verifiedUser.findFirst({
-        where: {
-          id: loginDto.userId,
-          NOT: { email: loginDto.email },
-        },
-        select: { email: true },
-      })
-
-      if (conflictingUser) {
-        throw new ForbiddenException(
-          'userId is already attached to another verified account'
-        )
-      }
-    }
-
     if (existingUser) {
+      // SignIn: the existing account's own id wins - never generate a fresh
+      // one. But refuse when the current session's userId is already attached
+      // to a different verified account: using it as `previousUserId` would
+      // reconcile that account's data into this one, and the id column of
+      // VerifiedUser is not unique, so a shared id would silently keep
+      // violating the invariant.
+      if (sessionUserId && existingUser.id !== sessionUserId) {
+        const conflictingUser = await session.verifiedUser.findFirst({
+          where: {
+            id: sessionUserId,
+            NOT: { email: loginDto.email },
+          },
+          select: { email: true },
+        })
+
+        if (conflictingUser) {
+          throw new ForbiddenException(
+            'userId is already attached to another verified account'
+          )
+        }
+      }
+
       return [existingUser, VerificationCodeMode.signIn] as const
     }
 
-    // SignUp if user doesn't exist
+    // SignUp if user doesn't exist. Reuse the session userId only when it is
+    // not already attached to another verified account (a free anonymous
+    // identity keeps the user's data attached). When it is taken - typically
+    // when signing up a new email while already authenticated as another
+    // account - start a fresh identity so that one id never maps to several
+    // accounts.
+    let newUserId: string = randomUUID()
+    if (sessionUserId) {
+      const takenUserId = await session.verifiedUser.findFirst({
+        where: { id: sessionUserId },
+        select: { email: true },
+      })
+      if (!takenUserId) {
+        newUserId = sessionUserId
+      }
+    }
+
     const { user: newUser } = await createOrUpdateVerifiedUser(
       {
-        id: { id: loginDto.userId, email: loginDto.email },
+        id: { id: newUserId, email: loginDto.email },
         user: loginDto,
         select: defaultVerifiedUserSelection,
       },

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -138,10 +138,11 @@ export const login = async ({
   loginDto: LoginDto
   locale: Locales
   /**
-   * The current session's userId, forwarded by the proxy as the `x-user-id`
-   * header. The server relies on it to enforce the
-   * "one session userId = one account" invariant instead of trusting a
-   * client-provided id.
+   * The current session's userId, forwarded by the site's `fetchServer` as
+   * the `x-user-id` header. The login route only accepts requests carrying
+   * the shared `x-internal-key`, so this id comes from the signed session
+   * cookie - not from the browser. The server relies on it to enforce the
+   * "one session userId = one account" invariant.
    */
   sessionUserId?: string
 }) => {

--- a/apps/server/src/features/authentication/authentication.service.ts
+++ b/apps/server/src/features/authentication/authentication.service.ts
@@ -174,6 +174,25 @@ export function createToken(user: Pick<VerifiedUser, 'id' | 'email'>) {
   )
 }
 
+/**
+ * Returns the verified account that already owns `userId`, unless it is the
+ * account identified by `email`.
+ *
+ * `VerifiedUser.id` is not unique in the schema - only `email` is the primary
+ * key - so nothing in the database stops two accounts from sharing a userId.
+ * The application enforces the "one session userId = one account" invariant
+ * here, at every account entry point, by refusing to let an id belong to two
+ * verified accounts.
+ */
+const findOtherVerifiedAccountWithUserId = (
+  { userId, email }: { userId: string; email: string },
+  { session }: { session: Session }
+) =>
+  session.verifiedUser.findFirst({
+    where: { id: userId, NOT: { email } },
+    select: { email: true },
+  })
+
 export async function createAccountOrSignin({
   loginDto,
   sessionUserId,
@@ -195,46 +214,42 @@ export async function createAccountOrSignin({
 
     if (existingUser) {
       // SignIn: the existing account's own id wins - never generate a fresh
-      // one. But refuse when the current session's userId is already attached
-      // to a different verified account: using it as `previousUserId` would
-      // reconcile that account's data into this one, and the id column of
-      // VerifiedUser is not unique, so a shared id would silently keep
-      // violating the invariant.
-      if (sessionUserId && existingUser.id !== sessionUserId) {
-        const conflictingUser = await session.verifiedUser.findFirst({
-          where: {
-            id: sessionUserId,
-            NOT: { email: loginDto.email },
-          },
-          select: { email: true },
-        })
-
-        if (conflictingUser) {
-          throw new ForbiddenException(
-            'userId is already attached to another verified account'
-          )
-        }
+      // one. Only refuse when the session's userId already belongs to another
+      // verified account: the login event reconciles the session's data
+      // (previousUserId) into this account, which would move that other
+      // account's data over and delete its user row.
+      if (
+        sessionUserId &&
+        sessionUserId !== existingUser.id &&
+        (await findOtherVerifiedAccountWithUserId(
+          { userId: sessionUserId, email: loginDto.email },
+          { session }
+        ))
+      ) {
+        throw new ForbiddenException(
+          'userId is already attached to another verified account'
+        )
       }
 
       return [existingUser, VerificationCodeMode.signIn] as const
     }
 
-    // SignUp if user doesn't exist. Reuse the session userId only when it is
-    // not already attached to another verified account (a free anonymous
-    // identity keeps the user's data attached). When it is taken - typically
-    // when signing up a new email while already authenticated as another
-    // account - start a fresh identity so that one id never maps to several
-    // accounts.
-    let newUserId: string = randomUUID()
-    if (sessionUserId) {
-      const takenUserId = await session.verifiedUser.findFirst({
-        where: { id: sessionUserId },
-        select: { email: true },
-      })
-      if (!takenUserId) {
-        newUserId = sessionUserId
-      }
-    }
+    // SignUp: reuse the session userId as the account id only when it is
+    // still a free anonymous identity - the anonymous user row is then
+    // updated in place, keeping the user's data attached. When it already
+    // belongs to another verified account (typically signing up a new email
+    // while authenticated as another account), start a fresh identity so one
+    // id never maps to several accounts.
+    const otherAccountWithUserId = sessionUserId
+      ? await findOtherVerifiedAccountWithUserId(
+          { userId: sessionUserId, email: loginDto.email },
+          { session }
+        )
+      : null
+
+    const newUserId = otherAccountWithUserId
+      ? randomUUID()
+      : (sessionUserId ?? randomUUID())
 
     const { user: newUser } = await createOrUpdateVerifiedUser(
       {

--- a/apps/server/src/features/authentication/authentication.validator.ts
+++ b/apps/server/src/features/authentication/authentication.validator.ts
@@ -2,7 +2,6 @@ import * as v from 'valibot'
 import { LocaleQuery } from '../../core/i18n/lang.validator.ts'
 
 export const LoginDto = v.strictObject({
-  userId: v.pipe(v.string(), v.uuid()),
   email: v.pipe(
     v.string(),
     v.email(),

--- a/apps/server/src/features/authentication/events/Login.event.ts
+++ b/apps/server/src/features/authentication/events/Login.event.ts
@@ -6,7 +6,7 @@ import { EventBusEvent } from '../../../core/event-bus/event.ts'
 import type { Locales } from '../../../core/i18n/constant.ts'
 export class LoginEvent extends EventBusEvent<{
   user: Pick<VerifiedUser, 'id' | 'email'>
-  previousUserId: string
+  previousUserId: string | undefined
   mode: VerificationCodeMode
   locale: Locales
 }> {

--- a/apps/server/src/features/authentication/handlers/reconcile-simulations-after-login.ts
+++ b/apps/server/src/features/authentication/handlers/reconcile-simulations-after-login.ts
@@ -10,8 +10,9 @@ export const reconcileSimulationsAfterLogin: Handler<LoginEvent> = ({
     return
   }
 
-  // Skip reconciliation when the anon session userId is already the verified user's id
-  if (previousUserId === user.id) {
+  // Skip reconciliation when the anon session userId is already the verified
+  // user's id, or when there is no session userId to reconcile from.
+  if (!previousUserId || previousUserId === user.id) {
     return
   }
 

--- a/apps/site/src/helpers/server/proxy/migrate-legacy-sessions.middleware.ts
+++ b/apps/site/src/helpers/server/proxy/migrate-legacy-sessions.middleware.ts
@@ -66,9 +66,8 @@ export async function middlewareMigrateLegacySessions(
     redirect: null,
     cookies: [
       ...buildSessionCookies(tokens),
-      // @tofix on garde les cookies legacy, le temps d’être sûr de ne pas avoir besoin de revert
-      // { name: LEGACY_SESSION_COOKIE!, value: '', options: { maxAge: 0 } },
-      // { name: ANON_SESSION_COOKIE, value: '', options: { maxAge: 0 } },
+      { name: LEGACY_SESSION_COOKIE!, value: '', options: { maxAge: 0 } },
+      { name: ANON_SESSION_COOKIE, value: '', options: { maxAge: 0 } },
     ],
   }
 }

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -31,12 +31,22 @@ export const login = async ({
 }): Promise<Result<{ userId: string; id: string }, CodeError>> => {
   try {
     const session = await getUserSession()
+    // Reusing the current session's userId for a *different* account is what
+    // ends up attaching one id to several verified accounts (the server only
+    // rejects it on signin, after the damage is done on signup). Starting a
+    // fresh identity here keeps the 1 session id = 1 account invariant.
+    const isSwitchingAccount =
+      session?.isAuth === true && session.email !== email
     const params = locale ? `?locale=${locale}` : ''
     const data = await fetchServer<{ id: string }>(
       `${AUTHENTICATION_URL}/login${params}`,
       {
         method: 'POST',
-        body: { email, code, userId: session?.id ?? v4() },
+        body: {
+          email,
+          code,
+          userId: isSwitchingAccount ? v4() : (session?.id ?? v4()),
+        },
       }
     )
 

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -16,7 +16,6 @@ import { fetchServer } from '@/helpers/server/fetchServer'
 import { revokeAllSessions } from '@nosgestesclimat/core/features/auth/services/revoke-all-sessions.service'
 import { failure, success, type Result } from '@nosgestesclimat/core/lib/result'
 import { revalidatePath } from 'next/cache'
-import { v4 } from 'uuid'
 import { createAppSession } from './create-app-session'
 import { getUserSession } from './get-user-session'
 
@@ -31,21 +30,19 @@ export const login = async ({
 }): Promise<Result<{ userId: string; id: string }, CodeError>> => {
   try {
     const session = await getUserSession()
-    // Reusing the current session's userId for a *different* account is what
-    // ends up attaching one id to several verified accounts (the server only
-    // rejects it on signin, after the damage is done on signup). Starting a
-    // fresh identity here keeps the 1 session id = 1 account invariant.
-    const isSwitchingAccount =
-      session?.isAuth === true && session.email !== email
     const params = locale ? `?locale=${locale}` : ''
     const data = await fetchServer<{ id: string }>(
       `${AUTHENTICATION_URL}/login${params}`,
       {
         method: 'POST',
+        // The current session's userId is forwarded to the server as the
+        // `x-user-id` header by `fetchServer`: the server is the one deciding
+        // which userId to attach to the account (reusing the session's when
+        // free, generating a fresh one when switching accounts), so the
+        // "one session id = one account" invariant is enforced there.
         body: {
           email,
           code,
-          userId: isSwitchingAccount ? v4() : (session?.id ?? v4()),
         },
       }
     )


### PR DESCRIPTION
## Contexte

Bug détecté : plusieurs comptes pouvaient partager le **même identifiant de session**. À la création de compte, le `userId` de la session entrante était réutilisé comme identifiant du compte **sans vérification d'unicité** → en production, **259 identifiants étaient partagés par plusieurs comptes**.

## Changement

- **Serveur** (`authentication.service.ts`) : garde **« un identifiant de session = un compte »**. Si le `userId` envoyé appartient déjà à un autre compte (email différent), la connexion est refusée (403) au lieu de réutiliser/mélanger l'identifiant.
- **Client** (`login.ts`) : quand la session courante est authentifiée avec un email différent de celui demandé (changement de compte dans le même navigateur), un identifiant frais (`v4()`) est généré au lieu de réutiliser celui de la session.

## Tests

- `login.spec.ts` : la garde serveur refuse un id appartenant à un autre compte ; un identifiant frais est généré au changement de compte.

## Dépendances

À merger **avant** les PR « message de conflit » et « migration des identifiants partagés ».
