### PR TITLE
💬 Show a generic, translated error message when a session blocks login

### DIFF
--- a/apps/site/src/components/authentication/__tests__/errors.test.ts
+++ b/apps/site/src/components/authentication/__tests__/errors.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { AccountConflictError } from '../errors'
 
 describe('AccountConflictError', () => {
-  it('exposes the account_conflict code with an actionable message', () => {
+  it('exposes the account_conflict code with a generic message', () => {
     const error = new AccountConflictError()
     expect(error.code).toBe('account_conflict')
-    expect(error.message).toBe('Session déjà associée à un autre compte')
+    // Kept generic on purpose: a specific message would let an attacker
+    // distinguish this rejection and enumerate existing accounts.
+    expect(error.message).toBe('Une erreur est survenue')
   })
 })

--- a/apps/site/src/components/authentication/__tests__/errors.test.ts
+++ b/apps/site/src/components/authentication/__tests__/errors.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import { AccountConflictError } from '../errors'
+
+describe('AccountConflictError', () => {
+  it('exposes the account_conflict code with an actionable message', () => {
+    const error = new AccountConflictError()
+    expect(error.code).toBe('account_conflict')
+    expect(error.message).toBe('Session déjà associée à un autre compte')
+  })
+})

--- a/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
+++ b/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
@@ -79,6 +79,12 @@ export default function VerificationCodeForm() {
         <p id="verification-error" className="mt-2 text-sm text-red-800 dark:text-white">
           {match(state.codeError.code)
             .with('invalid', () => t('signIn.code.invalid', 'Le code est invalide'))
+            .with('account_conflict', () =>
+              t(
+                'signIn.code.accountConflict',
+                'Cette session est déjà associée à un autre compte. Déconnectez-vous puis réessayez avec une nouvelle session.'
+              )
+            )
             .with('rate_limited', () => t('signIn.code.rateLimited', 'Veuillez patienter un instant avant de réessayer.'))
             .with('unknown', () => t('common.errors.errorHappening', 'Une erreur est survenue. Veuillez réessayer.'))
             .exhaustive()

--- a/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
+++ b/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/VerificationCodeForm.tsx
@@ -3,6 +3,7 @@
 import CheckCircleIcon from '@/components/icons/status/CheckCircleIcon'
 import Trans from '@/components/translation/trans/TransClient'
 import Button from '@/design-system/buttons/Button'
+import InlineLink from '@/design-system/inputs/InlineLink'
 import { defaultInputStyleClassNames } from '@/design-system/inputs/TextInput'
 import Loader from '@/design-system/layout/Loader'
 import { type ChangeEvent, type FormEvent, useCallback, useId, useState } from 'react'
@@ -79,12 +80,12 @@ export default function VerificationCodeForm() {
         <p id="verification-error" className="mt-2 text-sm text-red-800 dark:text-white">
           {match(state.codeError.code)
             .with('invalid', () => t('signIn.code.invalid', 'Le code est invalide'))
-            .with('account_conflict', () =>
-              t(
-                'signIn.code.accountConflict',
-                'Cette session est déjà associée à un autre compte. Déconnectez-vous puis réessayez avec une nouvelle session.'
-              )
-            )
+            .with('account_conflict', () => (
+              <Trans i18nKey="signIn.code.accountConflict">
+                Une erreur s'est produite. Veuillez{' '}
+                <InlineLink href="/contact">nous contacter</InlineLink> si elle persiste.
+              </Trans>
+            ))
             .with('rate_limited', () => t('signIn.code.rateLimited', 'Veuillez patienter un instant avant de réessayer.'))
             .with('unknown', () => t('common.errors.errorHappening', 'Une erreur est survenue. Veuillez réessayer.'))
             .exhaustive()

--- a/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/__tests__/VerificationCodeForm.test.tsx
+++ b/apps/site/src/components/authentication/authenticateUserForm/verifyCodeForm/__tests__/VerificationCodeForm.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuth } from '@/components/authentication/AuthProvider'
+import type { AuthContextValue } from '@/components/authentication/AuthProvider'
+import { AccountConflictError } from '@/components/authentication/errors'
+import VerificationCodeForm from '../VerificationCodeForm'
+
+vi.mock('@/components/authentication/AuthProvider', async () => {
+  const actual = await vi.importActual('@/components/authentication/AuthProvider')
+  return { ...actual, useAuth: vi.fn() }
+})
+
+const defaultAuth: AuthContextValue = {
+  state: { phase: 'idle', emailError: null },
+  sendEmail: vi.fn() as unknown as AuthContextValue['sendEmail'],
+  submitCode: vi.fn(),
+  resendCode: vi.fn() as unknown as AuthContextValue['resendCode'],
+  goBack: vi.fn(),
+  reset: vi.fn(),
+  clearCodeError: vi.fn(),
+  isCreatingCode: false,
+  mode: undefined,
+}
+
+describe('VerificationCodeForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a generic message with a contact link on account conflict', () => {
+    vi.mocked(useAuth).mockReturnValue({
+      ...defaultAuth,
+      state: {
+        phase: 'code_sent',
+        email: 'a@b.com',
+        pending: { email: 'a@b.com', expirationDate: new Date() },
+        cooldownUntil: 0,
+        isResending: false,
+        codeError: new AccountConflictError(),
+        resendError: null,
+      },
+    } as AuthContextValue)
+
+    render(<VerificationCodeForm />)
+
+    const link = screen.getByRole('link', { name: 'nous contacter' })
+    expect(link).toHaveAttribute('href', '/contact')
+    expect(screen.getByText(/si elle persiste\./)).toBeInTheDocument()
+    // The message must not reveal the session conflict (account-enumeration
+    // oracle): the previous specific wording is gone.
+    expect(screen.queryByText(/Session déjà associée/)).not.toBeInTheDocument()
+  })
+})

--- a/apps/site/src/components/authentication/errors.ts
+++ b/apps/site/src/components/authentication/errors.ts
@@ -22,10 +22,14 @@ export class UnknownCodeError extends DomainError<'unknown'> {
  * The server rejected the login because the current session (anonymous user
  * id) is already attached to another verified account. The user must start a
  * fresh session (log out / clear cookies) before logging in with this email.
+ *
+ * The message stays deliberately generic: a specific one would let an attacker
+ * distinguish this rejection from the others and use it as an account-existence
+ * oracle.
  */
 export class AccountConflictError extends DomainError<'account_conflict'> {
   constructor() {
-    super('account_conflict', 'Session déjà associée à un autre compte')
+    super('account_conflict', 'Une erreur est survenue')
   }
 }
 

--- a/apps/site/src/components/authentication/errors.ts
+++ b/apps/site/src/components/authentication/errors.ts
@@ -18,6 +18,21 @@ export class UnknownCodeError extends DomainError<'unknown'> {
   }
 }
 
-export type CodeError = InvalidCodeError | RateLimitedError | UnknownCodeError
+/**
+ * The server rejected the login because the current session (anonymous user
+ * id) is already attached to another verified account. The user must start a
+ * fresh session (log out / clear cookies) before logging in with this email.
+ */
+export class AccountConflictError extends DomainError<'account_conflict'> {
+  constructor() {
+    super('account_conflict', 'Session déjà associée à un autre compte')
+  }
+}
+
+export type CodeError =
+  | InvalidCodeError
+  | RateLimitedError
+  | UnknownCodeError
+  | AccountConflictError
 
 export type EmailError = RateLimitedError | UnknownCodeError

--- a/apps/site/src/locales/ui/ui-en.yaml
+++ b/apps/site/src/locales/ui/ui-en.yaml
@@ -972,6 +972,7 @@ entries:
   login.colourBlock.highlight3.title.strong: your collective challenges
   login.colourBlock.highlight3.title.strong.lock: vos défis collectifs
   login.list.signin.label: Create an account
+  signIn.code.accountConflict: Something went wrong. Please <2>contact us</2> if it persists.
   login.list.signin.label.lock: Créer un compte
   signup.colourBlock.highlight2.title.middle: and
   signup.colourBlock.highlight2.title.middle.lock: et

--- a/apps/site/src/locales/ui/ui-fr.yaml
+++ b/apps/site/src/locales/ui/ui-fr.yaml
@@ -846,6 +846,7 @@ entries:
   login.colourBlock.login.highlight3.strong2: retrouvez vos tests collectifs
   login.list.login.label: Se connecter
   login.list.signin.label: Créer un compte
+  signIn.code.accountConflict: Une erreur s'est produite. Veuillez <2>nous contacter</2> si elle persiste.
   login.login.title: Accédez à votre espace Nos Gestes Climat
   signup.button.label: M'inscrire
   signup.colourBlock.highlight1.title.prefix: Retrouvez

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import {
+  AccountConflictError,
   InvalidCodeError,
   RateLimitedError,
   UnknownCodeError,
@@ -61,7 +62,8 @@ export const login = async ({
   } catch (error) {
     if (error instanceof UnauthorizedError)
       return failure(new InvalidCodeError())
-    if (error instanceof ForbiddenError) return failure(new InvalidCodeError())
+    if (error instanceof ForbiddenError)
+      return failure(new AccountConflictError())
     if (error instanceof TooManyRequestsError)
       return failure(new RateLimitedError())
     return failure(new UnknownCodeError())


### PR DESCRIPTION
## Contexte

Suite de la PR **« Un identifiant = un compte »** (branchée sur `fix/one-session-one-account`). La garde serveur renvoie un 403 quand la session courante bloque une connexion ; sans ce changement, le client affichait « Le code est invalide » — un message trompeur pour l'utilisateur.

## Changement

- `errors.ts` : nouvelle erreur `AccountConflictError` (code interne `account_conflict`, message neutre).
- `login.ts` : le 403 est mappé sur `AccountConflictError`.
- `VerificationCodeForm.tsx` : message **générique** affiché — *« Une erreur s'est produite. Veuillez nous contacter si elle persiste. »* — avec lien vers la page contact (`/contact`), injecté via le pattern `Trans` + `InlineLink` utilisé ailleurs dans la codebase.
- Traductions ajoutées (`signIn.code.accountConflict`) en français et en anglais.
- Tests : `errors.test.ts` + nouveau test de rendu du message (`VerificationCodeForm.test.tsx`).

## Sécurité

Le message initial (*« Cette session est déjà associée à un autre compte »*) révélait l'association session ↔ compte : un attaquant contrôlant un identifiant de session pouvait s'en servir comme oracle (brute force / énumération). Le message affiché est désormais générique ; le code `account_conflict` reste distinct en interne (logique client, diagnostic) mais n'est jamais affiché tel quel.

## Note

Changement adapté à la structure `DomainError` de `main` (la branche d'origine avait refondu la couche d'erreurs, hors périmètre de cette PR).
