### PR TITLE
fix(e2e): regenerate job state when starting E2E tests, redirect server-side after joining a group

### DIFF
--- a/.github/workflows/site:e2e.yaml
+++ b/.github/workflows/site:e2e.yaml
@@ -17,43 +17,12 @@ env:
   NEXT_PUBLIC_SITE_URL: ${{ inputs.site_url }}
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    environment:
-      name: Test E2E
-      deployment: false
-    name: Setup
-    defaults:
-      run:
-        working-directory: ./apps/site
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Playwright and App
-        uses: ./.github/actions/setup-playwright
-
-      - name: Run setup tests
-        env:
-          MAILISK_API_KEY: ${{ secrets.MAILISK_API_KEY }}
-          MAILISK_NAMESPACE: ${{ vars.MAILISK_NAMESPACE }}
-        run: pnpm playwright test --project="global setup"
-
-      - name: Upload state artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: e2e-state
-          path: apps/site/e2e/state/*.json
-          retention-days: 1
-
-      - name: Upload blob report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: blob-report-setup
-          path: apps/site/blob-report
-          retention-days: 1
-
+  # Each e2e-tests job generates its own E2E state through the `global setup`
+  # Playwright project (declared as a dependency of the Chrome/Firefox projects).
+  # This guarantees the sessions baked into the states are always fresh, even when
+  # a job is re-run hours later. Previously, the states were produced once by a
+  # shared `setup` job and reused by both browser jobs: once the session JWT
+  # (20-min TTL) expired, re-runs made every authenticated test fail.
   e2e-tests:
     environment:
       name: Test E2E
@@ -71,7 +40,6 @@ jobs:
           #   browser: webkit
     runs-on: ubuntu-latest
     name: ${{ matrix.project }}
-    needs: [setup]
     defaults:
       run:
         working-directory: ./apps/site
@@ -84,17 +52,16 @@ jobs:
         with:
           browser: ${{ matrix.browser }}
 
-      - name: Download state artifacts
-        uses: actions/download-artifact@v6
-        with:
-          name: e2e-state
-          path: apps/site/e2e/state
+      # The `global setup` Playwright project runs in Desktop Chrome.
+      - name: Install Chromium for E2E state generation
+        if: ${{ matrix.browser != 'chromium' }}
+        run: pnpm playwright install chromium
 
       - name: Run E2E tests (${{ matrix.project }})
         env:
           MAILISK_API_KEY: ${{ secrets.MAILISK_API_KEY }}
           MAILISK_NAMESPACE: ${{ vars.MAILISK_NAMESPACE }}
-        run: pnpm playwright test --no-deps --project="${{ matrix.project }}"
+        run: pnpm playwright test --project="${{ matrix.project }}"
 
       - name: Upload blob report
         if: ${{ !cancelled() }}

--- a/apps/site/src/app/[locale]/(server)/(large)/amis/invitation/_actions/join-group.action.ts
+++ b/apps/site/src/app/[locale]/(server)/(large)/amis/invitation/_actions/join-group.action.ts
@@ -1,0 +1,32 @@
+'use server'
+
+import { TUTORIAL_PATH } from '@/constants/urls/paths'
+import { getLinkToGroupDashboard } from '@/helpers/navigation/groupPages'
+import type { Simulation } from '@/helpers/server/model/simulations'
+import { redirect } from 'next/navigation'
+
+import { updateGroupParticipant } from '@/services/groups/update-group-participant'
+
+/**
+ * Adds the visitor to the group then navigates. The redirect is issued
+ * server-side (via `redirect()`) so that the navigation does not depend on a
+ * client-side `router.push` after a server action, which can be dropped once
+ * the transition settles (observed with `cacheComponents`).
+ */
+export const joinGroup = async ({
+  groupId,
+  simulation,
+  name,
+}: {
+  groupId: string
+  simulation?: Simulation
+  name?: string
+}) => {
+  await updateGroupParticipant({ groupId, simulation, name })
+
+  if (simulation?.progression === 1) {
+    redirect(getLinkToGroupDashboard({ groupId }))
+  } else {
+    redirect(TUTORIAL_PATH)
+  }
+}

--- a/apps/site/src/app/[locale]/(server)/(large)/amis/invitation/_components/InvitationForm.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/amis/invitation/_components/InvitationForm.tsx
@@ -1,19 +1,16 @@
 'use client'
 
 import Trans from '@/components/translation/trans/TransClient'
-import { TUTORIAL_PATH } from '@/constants/urls/paths'
 import Button from '@/design-system/buttons/Button'
 import PrenomInput from '@/design-system/inputs/PrenomInput'
-import { getLinkToGroupDashboard } from '@/helpers/navigation/groupPages'
 import type { Simulation } from '@/helpers/server/model/simulations'
 import { useClientTranslation } from '@/hooks/useClientTranslation'
 import { useUser } from '@/publicodes-state'
 import type { Group } from '@/types/groups'
-import { useRouter } from 'next/navigation'
 import { useTransition } from 'react'
 
-import { updateGroupParticipant } from '@/services/groups/update-group-participant'
 import { useForm as useReactHookForm } from 'react-hook-form'
+import { joinGroup } from '../_actions/join-group.action'
 
 interface Inputs {
   guestName: string
@@ -40,22 +37,16 @@ export default function InvitationForm({
 
   const hasCompletedTest = currentSimulation?.progression === 1
 
-  const router = useRouter()
-
   function onSubmit({ guestName }: Inputs) {
     startTransition(async () => {
       updateName(guestName)
 
-      await updateGroupParticipant({
+      // Navigation is handled server-side by the action (redirect()).
+      await joinGroup({
         groupId: group.id,
+        simulation: currentSimulation,
         name: guestName,
       })
-
-      if (hasCompletedTest) {
-        router.push(getLinkToGroupDashboard({ groupId: group.id }))
-      } else {
-        router.push(TUTORIAL_PATH)
-      }
     })
   }
 


### PR DESCRIPTION
## Contexte

Les tests E2E Firefox du workflow Deploy (preprod) échouaient de façon répétée, bloquant les déploiements (run 195, attempts 1 à 4). L'investigation a identifié **deux problèmes distincts** :

### 1. Échec massif (32 tests) sur les re-runs

Le job `setup` générait un état E2E partagé (sessions JWT à TTL 20 min + refresh token à usage unique), téléchargé ensuite par les jobs Chrome et Firefox. Lorsqu'un job était **re-run des heures plus tard** (Chrome passe toujours, Firefox flake et déclenche les re-runs), le JWT était expiré :

- la rotation de session du middleware échouait sur les requêtes concurrentes (`TokenConsumedException`, refresh token mono-usage) ;
- la protection anti-rejeu (`_rt`) s'épuisait et le middleware **supprimait les cookies de session** (`ngc_session=; Max-Age=0`) ;
- le browser devenait anonyme → `/fin`, `/amis/resultats`, org dashboard et user account échouaient en masse.

**Fix :** suppression du job `setup` partagé. Chaque job `e2e-tests` génère désormais **son propre état** via le projet `global setup` (déclaré comme dépendance Playwright des projets Chrome/Firefox). Les sessions sont donc toujours fraîches, y compris en cas de re-run. (Le job Firefox installe Chromium, requis par le projet `global setup`.)

### 2. Flake initial (1-2 tests)

`groups.spec.ts` (« A user with a completed test that joined a group › see the group result page after joining ») flake en Firefox : après l'action de jointure, le `router.push` côté client pouvait être abandonné (avec `cacheComponents`, la route d'invitation reste montée dans le DOM), laissant l'utilisateur bloqué sur `/amis/invitation`.

**Fix :** nouvelle action serveur `joinGroup` qui appelle `updateGroupParticipant` puis `redirect()` **côté serveur**, comme le font déjà les autres actions de mutation (`createPoll`, `logout`, …). La navigation ne dépend plus d'un `router.push` client après une action serveur (pattern fragile dans `useTransition`). Le contournement ajouté dans le test E2E (re-navigation vers le lien d'invitation) a été retiré : le comportement est corrigé à la source.

## Note sécurité

Parmi les options de correction envisagées, celle-ci a été retenue car elle **ne touche à aucun mécanisme d'authentification** : le TTL de session (20 min), la rotation mono-usage et la protection anti-rejeu restent inchangés. Aucun assouplissement du middleware auth n'a été nécessaire.
