### PR TITLE
fix(auth): stop PPR-cached anonymous shell from looping /mon-espace after login

### DIFF
--- a/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/layout.tsx
+++ b/apps/site/src/app/[locale]/(server)/(large)/(user-account)/mon-espace/layout.tsx
@@ -1,6 +1,11 @@
 import { t } from '@/helpers/metadata/fakeMetadataT'
 import { getCommonMetadata } from '@/helpers/metadata/getCommonMetadata'
 
+// Auth-gated pages must never be served from the PPR static shell: the
+// `unauthorized` boundary redirect baked into the cached anonymous shell
+// would bounce authenticated users between /mon-espace and /connexion.
+export const dynamic = 'force-dynamic'
+
 export const generateMetadata = getCommonMetadata({
   title: t('Mon espace - Nos Gestes Climat'),
   description: t(

--- a/apps/site/src/services/auth/login.ts
+++ b/apps/site/src/services/auth/login.ts
@@ -12,6 +12,7 @@ import {
   TooManyRequestsError,
   UnauthorizedError,
 } from '@/helpers/server/error'
+import { MON_ESPACE_PATH } from '@/constants/urls/paths'
 import { fetchServer } from '@/helpers/server/fetchServer'
 import { revokeAllSessions } from '@nosgestesclimat/core/features/auth/services/revoke-all-sessions.service'
 import { failure, success, type Result } from '@nosgestesclimat/core/lib/result'
@@ -46,6 +47,7 @@ export const login = async ({
     await createAppSession(data.id, email)
 
     revalidatePath('/', 'layout')
+    revalidatePath(MON_ESPACE_PATH)
 
     return success({ ...data, userId: data.id })
   } catch (error) {


### PR DESCRIPTION
## Problem

On preprod, after entering the email verification code on `/connexion`, the user is redirected in an infinite loop between `/connexion` and `/mon-espace`. The login itself succeeds (the session cookie is set), but the browser never lands on the personal space.

## Root cause

`/mon-espace` is a Partial Prerendering (PPR) page (`cacheComponents: true`). Its static shell is prerendered and cached for 300s (`x-nextjs-stale-time: 300`) **keyed by URL only** — the cache does not account for the auth state.

When the page is rendered while anonymous, `requireAuthUser()` throws `unauthorized()`, and the `unauthorized.tsx` boundary calls `redirect('/connexion')`. This `NEXT_REDIRECT;replace;/connexion;307;` directive is baked into the cached anonymous static shell and served to **authenticated requests too** (verified on preprod: a request carrying an authenticated `x-session` header still returns the cached anonymous shell from `x-nextjs-cache: HIT`, with no user content).

The loop therefore is:

1. After login, the client calls `router.push('/mon-espace')`.
2. The router (or the server PPR cache) serves the **cached anonymous shell** whose RSC stream contains `NEXT_REDIRECT;replace;/connexion;307;`.
3. The client follows the redirect to `/connexion`.
4. `/connexion`'s login layout sees an authenticated session (`getUserSession()?.isAuth`) and calls `redirect(MON_ESPACE_PATH)` → `NEXT_REDIRECT;replace;/mon-espace;307;`.
5. Back to `/mon-espace`, served again from the anonymous cached shell → `/connexion` → loop until the 300s cache expires.

`revalidatePath('/', 'layout')` in `login()` was not sufficient: it does not invalidate the page-level PPR shell of `/mon-espace`, and the client router cache (300s stale-time) is separate.

## Fix

Two complementary changes:

- **`mon-espace/layout.tsx`**: add `export const dynamic = 'force-dynamic'`. Auth-gated pages must never be served from the PPR static shell; each request is now re-rendered from the actual `x-session` header, so the `unauthorized` redirect shell is never cached or served to authenticated users.
- **`login.ts`**: `revalidatePath(MON_ESPACE_PATH)` after `createAppSession`, invalidating the router cache for `/mon-espace` right after login.

## Validation

- Local `tsc --noEmit` and ESLint pass on the modified files.
- The existing logout e2e test remains valid: `force-dynamic` preserves the anonymous `unauthorized()` → `/connexion` redirect, it only stops caching it.
- Manual validation on `preprod.nosgestesclimat.fr` is still required after deploy (log in with a mailisk test user and confirm `/mon-espace` renders instead of bouncing).

## Follow-ups

The same latent pattern exists on other `unauthorized.tsx` pages (`organisations/[orgaSlug]`, `amis/creer`) — a follow-up could apply `force-dynamic` to those route groups too.

---

_This PR was created by an AI agent (OpenHands) on behalf of the repository maintainers._
