### PR TITLE
Add anonymous views for groups in ngc_anon schema

### DIFF
--- a/packages/core/prisma/migrations/20260811103200_add_groups_views_to_ngc_anon/migration.sql
+++ b/packages/core/prisma/migrations/20260811103200_add_groups_views_to_ngc_anon/migration.sql
@@ -2,7 +2,6 @@
 CREATE OR REPLACE VIEW "ngc_anon"."Group" AS
 SELECT
     "id",
-    "emoji",
     "createdAt",
     "updatedAt"
 FROM "ngc"."Group";

--- a/packages/core/prisma/migrations/20260811103200_add_groups_views_to_ngc_anon/migration.sql
+++ b/packages/core/prisma/migrations/20260811103200_add_groups_views_to_ngc_anon/migration.sql
@@ -1,0 +1,29 @@
+-- CreateView Group
+CREATE OR REPLACE VIEW "ngc_anon"."Group" AS
+SELECT
+    "id",
+    "emoji",
+    "createdAt",
+    "updatedAt"
+FROM "ngc"."Group";
+
+-- CreateView GroupAdministrator
+CREATE OR REPLACE VIEW "ngc_anon"."GroupAdministrator" AS
+SELECT
+    "id",
+    "userId",
+    "groupId",
+    "createdAt",
+    "updatedAt"
+FROM "ngc"."GroupAdministrator";
+
+-- CreateView GroupParticipant
+CREATE OR REPLACE VIEW "ngc_anon"."GroupParticipant" AS
+SELECT
+    "id",
+    "userId",
+    "simulationId",
+    "groupId",
+    "createdAt",
+    "updatedAt"
+FROM "ngc"."GroupParticipant";

--- a/packages/core/prisma/schema/ngc_anon.prisma
+++ b/packages/core/prisma/schema/ngc_anon.prisma
@@ -110,7 +110,6 @@ view AnonSimulationPoll {
 
 view AnonGroup {
   id            String                  @unique
-  emoji         String
   createdAt     DateTime
   updatedAt     DateTime
   administrator AnonGroupAdministrator?

--- a/packages/core/prisma/schema/ngc_anon.prisma
+++ b/packages/core/prisma/schema/ngc_anon.prisma
@@ -11,6 +11,7 @@ view AnonSimulation {
   user            AnonUser            @relation(fields: [userId], references: [id])
   userEmail       String?
   polls           AnonSimulationPoll[]
+  groups          AnonGroupParticipant[]
   createdAt       DateTime
   updatedAt       DateTime
 
@@ -19,12 +20,14 @@ view AnonSimulation {
 }
 
 view AnonUser {
-  id            String             @unique @db.Uuid
+  id            String                   @unique @db.Uuid
   ageRange      AgeRange?
   createdAt     DateTime
   updatedAt     DateTime
   simulations   AnonSimulation[]
   verifiedUsers AnonVerifiedUser[]
+  administrator AnonGroupAdministrator[]
+  member        AnonGroupParticipant[]
 
   @@map("User")
   @@schema("ngc_anon")
@@ -102,5 +105,46 @@ view AnonSimulationPoll {
   updatedAt    DateTime
 
   @@map("SimulationPoll")
+  @@schema("ngc_anon")
+}
+
+view AnonGroup {
+  id            String                  @unique
+  emoji         String
+  createdAt     DateTime
+  updatedAt     DateTime
+  administrator AnonGroupAdministrator?
+  participants  AnonGroupParticipant[]
+
+  @@map("Group")
+  @@schema("ngc_anon")
+}
+
+view AnonGroupAdministrator {
+  id        String    @unique @db.Uuid
+  userId    String    @db.Uuid
+  user      AnonUser  @relation(fields: [userId], references: [id])
+  group     AnonGroup @relation(fields: [groupId], references: [id])
+  groupId   String    @unique
+  createdAt DateTime
+  updatedAt DateTime
+
+  @@map("GroupAdministrator")
+  @@schema("ngc_anon")
+}
+
+view AnonGroupParticipant {
+  id           String         @unique @db.Uuid
+  userId       String         @db.Uuid
+  user         AnonUser       @relation(fields: [userId], references: [id])
+  simulationId String         @db.Uuid
+  simulation   AnonSimulation @relation(fields: [simulationId], references: [id])
+  group        AnonGroup      @relation(fields: [groupId], references: [id])
+  groupId      String
+  createdAt    DateTime
+  updatedAt    DateTime
+
+  @@unique([groupId, userId])
+  @@map("GroupParticipant")
   @@schema("ngc_anon")
 }


### PR DESCRIPTION
## Objectif

Exposer les données des groupes à travers des vues anonymisées dans le schéma `ngc_anon`, pour les métriques (comme fait précédemment pour les organisations et les sondages).

## Changements

- Ajout des vues `AnonGroup`, `AnonGroupAdministrator` et `AnonGroupParticipant` dans `packages/core/prisma/schema/ngc_anon.prisma`
- Migration SQL `20260811103200_add_groups_views_to_ngc_anon` créant les trois vues
- Relations Prisma ajoutées sur `AnonUser` (`administrator`, `member`) et `AnonSimulation` (`groups`)

## Données sensibles

Conformément au précédent NGC-3555 ("avoid name in anon schema"), le champ `name` des groupes n'est pas exposé dans la vue `AnonGroup`, afin de ne pas transmettre de données potentiellement sensibles. Les identifiants techniques (UUID) sont conservés pour permettre les jointures.