### PR TITLE
:wrench: Serve banner without caching on preprod and previews

### DIFF
--- a/apps/site/src/design-system/cms/Banner.tsx
+++ b/apps/site/src/design-system/cms/Banner.tsx
@@ -1,6 +1,13 @@
 import type { Locale } from '@/i18nConfig'
-import { fetchBanner } from '@/services/cms/fetchBanner'
+import { fetchBanner as fetchBannerCached } from '@/services/cms/fetchBanner.cached'
+import { fetchBanner as fetchBannerUncached } from '@/services/cms/fetchBanner'
+import { APP_ENV } from '../../../config/app-env'
 import { BannerContent } from './BannerContent'
+
+// Production-only 'use cache': preprod and preview apps read the banner live so
+// CMS changes appear immediately instead of after the cache expires.
+const fetchBanner =
+  APP_ENV === 'production' ? fetchBannerCached : fetchBannerUncached
 
 export default async function Banner({ locale }: { locale: Locale }) {
   const banner = await fetchBanner(locale)

--- a/apps/site/src/services/cms/fetchBanner.cached.ts
+++ b/apps/site/src/services/cms/fetchBanner.cached.ts
@@ -1,0 +1,14 @@
+import type { BannerType } from '@/adapters/cmsClient'
+import { type Locale } from '@/i18nConfig'
+import { cacheLife } from 'next/cache'
+import { fetchBanner as fetchBannerUncached } from './fetchBanner'
+
+// Production-only wrapper: 'use cache' keeps the banner out of the CMS for up
+// to an hour. Preprod and preview apps use the uncached version so CMS edits
+// appear immediately.
+export async function fetchBanner(locale: Locale): Promise<BannerType | null> {
+  'use cache'
+  cacheLife('hours')
+
+  return await fetchBannerUncached(locale)
+}

--- a/apps/site/src/services/cms/fetchBanner.ts
+++ b/apps/site/src/services/cms/fetchBanner.ts
@@ -3,11 +3,8 @@ import { cmsClient } from '@/adapters/cmsClient'
 import { type Locale } from '@/i18nConfig'
 import { captureException } from '@sentry/nextjs'
 import dayjs from 'dayjs'
-import { cacheLife } from 'next/cache'
 
 export async function fetchBanner(locale: Locale): Promise<BannerType | null> {
-  'use cache'
-  cacheLife('hours')
   try {
     const currentDate = dayjs()
 


### PR DESCRIPTION
## Description

The CMS banner was cached for one hour on **all** environments because `fetchBanner` used `'use cache'` + `cacheLife('hours')` unconditionally. As a result, CMS banner edits could take up to an hour to appear on preprod and on preview apps.

This change restricts the cache to production only, following the same pattern already used for the event page (production-only `'use cache'` wrapper).

## Changes

- `apps/site/src/services/cms/fetchBanner.ts`: removed `'use cache'` / `cacheLife('hours')` — this is now the live, uncached implementation.
- `apps/site/src/services/cms/fetchBanner.cached.ts` (new): cached wrapper (`'use cache'` + `cacheLife('hours')`) delegating to the uncached implementation.
- `apps/site/src/design-system/cms/Banner.tsx`: picks the cached version only when `APP_ENV === 'production'`, otherwise the live version.

`APP_ENV` (in `apps/site/config/app-env.ts`) already classifies both preprod (`preprod.nosgestesclimat.fr`) and preview apps (Scalingo review apps) as `'preprod'`, so a single production check covers both environments.

## Behavior

| Environment | Banner cache |
|---|---|
| Production | Unchanged (1 hour) |
| Preprod | Live |
| Preview apps | Live |
| Local dev | Live |

Note: on preprod/preview the underlying `cmsClient` fetch still revalidates every 5 seconds (non-production), so CMS edits appear within ~5s.

## Verification

- ESLint passes on the modified files
- `tsc --noEmit` passes
- All 208 site tests pass